### PR TITLE
CSS  Changes, Titles, Icons - Less Purple, Title/Header Emphasis, Icon Test

### DIFF
--- a/www/css/gccollab.css
+++ b/www/css/gccollab.css
@@ -354,10 +354,8 @@ a.color-gccollab {
 .theme-gccollab .button:not(.button-fill) { color: #46246A; }
 
 .theme-gccollab .navbar .button:not(.button-fill),
-.theme-gccollab .subnavbar .button:not(.button-fill),
 .theme-gccollab .toolbar .button:not(.button-fill),
 .theme-gccollab.navbar .button:not(.button-fill),
-.theme-gccollab.subnavbar .button:not(.button-fill),
 .theme-gccollab.toolbar .button:not(.button-fill) {
     color: #fff;
 }
@@ -484,10 +482,23 @@ i.icon-bars.theme-gccollab {
 .subnavbar.theme-gccollab,
 .theme-gccollab .navbar,
 .theme-gccollab .searchbar,
-.theme-gccollab .subnavbar,
 .theme-gccollab .toolbar,
 .toolbar.theme-gccollab {
     background-color: #46246A;
+}
+
+.theme-gccollab .subnavbar .button:not(.button-fill),
+.theme-gccollab.subnavbar .button:not(.button-fill),
+.subnavbar.theme-gccollab,
+.theme-gccollab .subnavbar {
+    background-color: #C7C7C7;
+    color: #000;
+}
+.theme-gccollab .card-header {
+    text-shadow: 2px 2px 4px black;
+}
+.theme-gccollab .navbar .center {
+    text-shadow: 2px 2px 4px black;
 }
 
 .range-slider.theme-gccollab input[type=range]::-webkit-slider-thumb:before,

--- a/www/css/gccollab.css
+++ b/www/css/gccollab.css
@@ -491,7 +491,7 @@ i.icon-bars.theme-gccollab {
 .theme-gccollab.subnavbar .button:not(.button-fill),
 .subnavbar.theme-gccollab,
 .theme-gccollab .subnavbar {
-    background-color: #C7C7C7;
+    background-color: #e8e8e8;
     color: #000;
 }
 .theme-gccollab .card-header {

--- a/www/css/gccollab.css
+++ b/www/css/gccollab.css
@@ -487,12 +487,14 @@ i.icon-bars.theme-gccollab {
     background-color: #46246A;
 }
 
+.theme-gccollab .toolbar-bottom,
+.theme-gccollab .toolbar-bottom i,
 .theme-gccollab .subnavbar .button:not(.button-fill),
 .theme-gccollab.subnavbar .button:not(.button-fill),
 .subnavbar.theme-gccollab,
 .theme-gccollab .subnavbar {
     background-color: #e8e8e8;
-    color: #000;
+    color: #46246A;
 }
 .theme-gccollab .card-header {
     text-shadow: 2px 2px 4px black;

--- a/www/css/gccollab.css
+++ b/www/css/gccollab.css
@@ -496,6 +496,10 @@ i.icon-bars.theme-gccollab {
     background-color: #e8e8e8;
     color: #46246A;
 }
+
+.theme-gccollab .subnavbar {
+    font-weight: bolder;
+}
 .theme-gccollab .card-header {
     text-shadow: 2px 2px 4px black;
 }

--- a/www/css/gccollab.css
+++ b/www/css/gccollab.css
@@ -491,7 +491,7 @@ i.icon-bars.theme-gccollab {
 .theme-gccollab.subnavbar .button:not(.button-fill),
 .subnavbar.theme-gccollab,
 .theme-gccollab .subnavbar {
-    background-color: #e8e8e8;
+    background-color: #ded5e8;
     color: #000;
 }
 .theme-gccollab .card-header {

--- a/www/css/gccollab.css
+++ b/www/css/gccollab.css
@@ -491,7 +491,7 @@ i.icon-bars.theme-gccollab {
 .theme-gccollab.subnavbar .button:not(.button-fill),
 .subnavbar.theme-gccollab,
 .theme-gccollab .subnavbar {
-    background-color: #ded5e8;
+    background-color: #e8e8e8;
     color: #000;
 }
 .theme-gccollab .card-header {

--- a/www/home.html
+++ b/www/home.html
@@ -68,7 +68,7 @@
     <div class="speed-dial-buttons">
       <!-- <a onclick="GCTUser.NewMessage();"><i class="fa fa-envelope"></i></a> -->
       <!-- <a onclick="GCTUser.NewBlogPost();"><i class="fa fa-pencil-square-o"></i></a> -->
-      <a onclick="GCTUser.PostWirePost();"> <i class="fa fa-comment"></i></a>
+      <a onclick="GCTUser.PostWirePost();"> <i class="fa fa-feed"></i></a>
     </div>
   </div>
 </div>

--- a/www/wire.html
+++ b/www/wire.html
@@ -16,8 +16,8 @@
 
     <div class="toolbar toolbar-bottom">
         <div class="toolbar-inner">
-            <div class="left sliding"><a href="#" class="link back" aria-label="Back Button"><i class="icon icon-back"></i></a></div>
-            <div class="right sliding"><a href="#" class="link icon-only" onclick="GCTUser.PostWirePost();"><i class="fa fa-comment"></i></a></div>
+            <div class="left sliding"><a href="#" class="link back" aria-label="Back Button"><i class="fa fa-arrow-circle-o-left fa-2x"></i></a></div>
+            <div class="right sliding"><a href="#" class="link icon-only" onclick="GCTUser.PostWirePost();"><i class="fa fa-feed fa-2x"></i></a></div>
         </div>
     </div>
 


### PR DESCRIPTION
Subnav: Light grey with collab purple text.
Toolbar: light grey with collab purple text. Testing icon size and back arrow choice.

Card-Header: Shadow for emphasis.
Navbar Center: Shadow for emphasis.

Post a Wire icon is now the same as it's global navigation icon, rather than the chat box that matches the chat related icons.

Before 
![current-entitylist](https://user-images.githubusercontent.com/34379222/37302961-64eefdbe-2603-11e8-8d68-ceb887a8aa06.PNG)

After
![new-list](https://user-images.githubusercontent.com/34379222/37305528-1a9ce19c-260b-11e8-87bc-d6c3bde6b20d.PNG)

