### PR TITLE
Global Nav Bar - Groups, Newsfeed, Wires

### DIFF
--- a/www/groups.html
+++ b/www/groups.html
@@ -1,9 +1,7 @@
 <div data-page="groups" class="page navbar-fixed with-subnavbar">
     <div class="navbar">
         <div class="navbar-inner">
-            <div class="left sliding"><a href="#" data-panel="left" class="open-panel link icon-only" aria-label="Button to open Site Navigation Menu"><i class="icon icon-bars"></i></a></div>
-            <div class="center" data-translate="groups">Groups</div>
-            <div class="right sliding"><a href="#" data-panel="right" class="open-panel link icon-only" aria-label="Button to open Notification Panel"><i class="fa fa-bell badge-wrapper"></i></a></div>
+            
         </div>
         <div class="subnavbar">
             <div class="buttons-row">

--- a/www/js/GCT.js
+++ b/www/js/GCT.js
@@ -412,6 +412,12 @@ GCTLang = {
             + '<li>';
         return contentNew;
     },
+    txtGlobalNav: function (title) {
+        var content = '<div class="left sliding"><a href="#" data-panel="left" class="open-panel link icon-only" aria-label="Button to open Site Navigation Menu"><i class="icon icon-bars"></i></a></div>' +
+            '<div class="center" id="entity-title">' + GCTLang.Trans(title) + '</div>' +
+            '<div class="right sliding"><a href="#" data-panel="right" class="open-panel link icon-only" aria-label="Button to open Notification Panel"><i class="fa fa-bell badge-wrapper"></i></a></div>';
+        return content;
+    },
     liGEDSResult: function (object) {
         var content = "<li class='item-content'>"
             + "<div class='item-inner'>"

--- a/www/js/gccollab.js
+++ b/www/js/gccollab.js
@@ -1177,6 +1177,7 @@ function Translate(obj) {
 }
 
 myApp.onPageInit('wire', function (page) {
+    $$('.navbar-inner').html(GCTLang.txtGlobalNav('the-wire'));
     var limit = 20;
     var offset = 0;
     var wiresAllMoreOffset = 0;
@@ -1334,6 +1335,7 @@ myApp.onPageInit('wire', function (page) {
 });
 
 myApp.onPageInit('newsfeed', function (page) {
+    $$('.navbar-inner').html(GCTLang.txtGlobalNav('newsfeed'));
     var limit = 20;
     var offset = 0;
     var newsfeedMoreOffset = 0;
@@ -1389,6 +1391,7 @@ myApp.onPageInit('newsfeed', function (page) {
 });
 
 myApp.onPageInit('groups', function (page) {
+    $$('.navbar-inner').html(GCTLang.txtGlobalNav('groups'));
     var limit = 20;
     var offset = 0;
     var groupsAllMoreOffset = 0;

--- a/www/newsfeed.html
+++ b/www/newsfeed.html
@@ -1,9 +1,7 @@
 <div data-page="newsfeed" class="page navbar-fixed">
   <div class="navbar">
       <div class="navbar-inner">
-          <div class="left sliding"><a href="#" data-panel="left" class="open-panel link icon-only" aria-label="Button to open Site Navigation Menu"><i class="icon icon-bars"></i></a></div>
-          <div class="center" data-translate="newsfeed">Newsfeed</div>
-          <div class="right sliding"><a href="#" data-panel="right" class="open-panel link icon-only" aria-label="Button to open Notification Panel"><i class="fa fa-bell badge-wrapper"></i></a></div>
+
       </div>
   </div>
 

--- a/www/wire.html
+++ b/www/wire.html
@@ -1,9 +1,7 @@
 <div data-page="wire" class="page navbar-fixed  with-subnavbar">
     <div class="navbar">
         <div class="navbar-inner">
-            <div class="left sliding"><a href="#" data-panel="left" class="open-panel link icon-only" aria-label="Button to open Site Navigation Menu"><i class="icon icon-bars"></i></a></div>
-            <div class="center" data-translate="the-wire">The Wire</div>
-            <div class="right sliding"><a href="#" data-panel="right" class="open-panel link icon-only" aria-label="Button to open Notification Panel"><i class="fa fa-bell badge-wrapper"></i></a></div>
+
         </div>
         <div class="subnavbar">
             <div class="buttons-row">


### PR DESCRIPTION
txtGlobalNav(title) returns navbar with title set. Insert into the navbar-inner. Makes one location control the navbar instead of each file seperately.

Added on Groups, Newsfeed, and Wires. Test if any issues arise before adding all pages.

#101 