### PR TITLE
New Members Card

### DIFF
--- a/www/js/GCT.js
+++ b/www/js/GCT.js
@@ -226,25 +226,17 @@ GCTLang = {
         return content;
     },
     txtMember: function (object) {
-        var content = "<div id='member-" + object.guid + "' class='swiper-slide list-block cards-list media-list'>"
-            + "<div class='card'>"
-                + "<div class='card-header' onclick='ShowProfile(" + object.guid + ");'>"
-                    + "<div class='item-media rounded'><img alt='Profile Image of " + object.name +"' src='" + object.icon + "' /></div>"
-                    + "<div class='item-inner'>"
-                        + "<div class='item-title-row'>"
-                            + "<div class='item-title'>" + object.name + "</div>"
-                            + "</div>"
-                        + "<div class='item-subtitle'>" + object.organization + "</div>"
-                    + "</div>"
-                + "</div>"
-                + "<div class='card-content'>"
-                    + "<div class='card-content-inner'>"
-                        + "<div class='item-text'>" + object.description + "</div>"
-                    + "</div>"
-                + "</div>"
-                + "<div class='card-footer'>" + object.date + "</div>"
+        console.log(object);
+        var content = "<a class='item-link item-content close-popup' data-guid='" + object.guid + "' data-type='gccollab_user' onclick='ShowProfile("+object.guid+");'>"
+            + "<div class='item-inner'>"
+            + "<div class='item-title-row no-padding-right'>"
             + "</div>"
-        + "</div>";
+            + "<div class='row ptm'>"
+            + "<div class='col-20'><img src='" + object.icon + "' width='50' alt='" + object.name + "'></div>"
+            + "<div class='col-80 item-title reg-text'>" + object.name + "<div class='item-text more_text'>" + object.organization + "</div> <div class='item-text more_text'> " + object.job + "</div></div>"
+            + "</div>"
+            + "</div>"
+            + "</a>";
         content = GCT.SetLinks(content);
         return content;
     },
@@ -2389,11 +2381,12 @@ GCTEach = {
         return content;
     },
     Member: function (value) {
-        var description = (value.about) ? urlify(value.about) : (value.job ? value.job : GCTLang.Trans('no-profile'));
+        var description = (value.about) ? urlify(value.about) : GCTLang.Trans('no-profile');
         var content = GCTLang.txtMember({
             guid: value.user_id,
             icon: value.iconURL,
             name: value.displayName,
+            job: (value.job) ? value.job : '',
             date: GCTLang.Trans("join-date") + "<em>" + prettyDate(value.dateJoined) + "</em>",
             description: description,
             organization: value.organization

--- a/www/members.html
+++ b/www/members.html
@@ -7,8 +7,8 @@
         </div>
         <div class="subnavbar">
             <div class="buttons-row">
-                <a href="#tab-all-members" class="button active tab-link">All</a>
-                <a href="#tab-colleagues-members" class="button tab-link">My Colleagues</a>
+                <a href="#tab-all-members" class="button tab-link">All</a>
+                <a href="#tab-colleagues-members" class="button  active tab-link">My Colleagues</a>
             </div>
         </div>
     </div>
@@ -26,12 +26,12 @@
       <div class="pull-to-refresh-arrow"></div>
     </div>
     <div class="tabs">
-      <div id="tab-all-members" class="tab active">
-        <div id="members-all" class="context"></div>
+      <div id="tab-all-members" class="tab">
+        <div class="list-block media-list"><ul id="members-all"></ul></div>
         <a id="members-all-more" class="button button-big button-fill" data-translate="view-more">VIEW MORE</a>
       </div>
-      <div id="tab-colleagues-members" class="tab">
-        <div id="members-colleagues" class="context"></div>
+      <div id="tab-colleagues-members" class="tab  active">
+        <div class="list-block media-list"><ul id="members-colleagues"></ul></div>
         <a id="members-colleagues-more" class="button button-big button-fill" data-translate="view-more">VIEW MORE</a>
       </div>
     </div>


### PR DESCRIPTION
Changed members card to be simple and clean, rather than using the default content cards.

Job Title seperated from description.

Description not used, currently.

Default members page tab is colleagues, not all.

closes #103 

![newmemberscard](https://user-images.githubusercontent.com/34379222/37406109-c34586f2-276c-11e8-84d0-1e57703fce6b.PNG)
