### PR TITLE
Image Content Max Width

### DIFF
--- a/www/css/gccollab.css
+++ b/www/css/gccollab.css
@@ -969,7 +969,7 @@ input:focus {
 .list-block.media-list{margin: 0;}
 .author { font-size: 14px; }
 .time {font-size: 12px; color: #60BB87;}
-img.article {width: 100%;height: auto;margin-top: 0;}
+img {width: 100%;height: auto;margin-top: 0;}
 .article-title { font-weight: 200; font-size: 24px; color: #222222; margin: 15px 0; padding: 0 15px;}
 .article-content { color: #666666; margin: 20px 0; padding: 0 15px; line-height: 25px;}
 .readmore { margin: 15px 0; padding: 0 15px;}


### PR DESCRIPTION
Fixes blog images going full size off screen.

Might need to watch for any unchecked places where this causes an issue.

closes #124 

![picturefit](https://user-images.githubusercontent.com/34379222/37730961-56ef5716-2d17-11e8-8ea4-bc8f052af993.PNG)
