### PR TITLE
Upgrade Versions PhoneGap 8

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -14,7 +14,7 @@
     <preference name="ShowSplashScreenSpinner" value="false" />
     <preference name="AutoHideSplashScreen" value="true" />
     <preference name="DisallowOverscroll" value="true" />
-    <preference name="StatusBarOverlaysWebView" value="false" />
+    <preference name="StatusBarOverlaysWebView" value="true" />
     <preference name="StatusBarStyle" value="lightcontent" />
     <preference name="StatusBarBackgroundColor" value="#46246A" />
     
@@ -71,6 +71,10 @@
         <splash src="res/screens/ios/screen-ipad-portrait-2x.png" width="1536" height="2048" />
     </platform>
 
+    <feature name="StatusBar">
+      <param name="ios-package" value="CDVStatusBar" onload="true" />
+    </feature>
+
     <icon src="icon.png" />
     <splash src="splash.png" />
 
@@ -81,6 +85,7 @@
     <plugin name="cordova-plugin-console"  />
     <plugin name="cordova-plugin-statusbar"  />
     <plugin name="cordova-plugin-inappbrowser" />
-
+    <plugin name="cordova-plugin-file-transfer" spec="~1.7.1" />
+    <plugin name="cordova-plugin-camera" spec="~4.0.2" />
 
 </widget>

--- a/config.xml
+++ b/config.xml
@@ -8,7 +8,7 @@
     <content src="https://gctools.ca/gctoolkit/index.html" />
     -->
     <content src="www/index.html" />
-
+    <preference name="phonegap-version" value="cli-8.0.0" />
     <preference name="SplashScreenDelay" value="1500" />
     <preference name="FadeSplashScreen" value="false" />
     <preference name="ShowSplashScreenSpinner" value="false" />
@@ -26,7 +26,7 @@
     <allow-intent href="geo:*" />
 
     <platform name="android">
-        <preference name="android-minSdkVersion" value="14" />
+        <preference name="android-minSdkVersion" value="19"/>
         <allow-intent href="market:*" />
         <icon qualifier="ldpi" src="res/icons/android/icon-36-ldpi.png" />
         <icon qualifier="mdpi" src="res/icons/android/icon-48-mdpi.png" />

--- a/config.xml
+++ b/config.xml
@@ -77,10 +77,10 @@
     <access origin="*" />
     <allow-navigation href="*" />
 
-    <plugin name="cordova-plugin-whitelist" spec="~1.2.2" />
-    <plugin name="cordova-plugin-console" spec="~1.0.7" />
-    <plugin name="cordova-plugin-statusbar" spec="~1.0.1" />
-    <plugin name="cordova-plugin-inappbrowser" spec="~1.7.1" />
+    <plugin name="cordova-plugin-whitelist"  />
+    <plugin name="cordova-plugin-console"  />
+    <plugin name="cordova-plugin-statusbar"  />
+    <plugin name="cordova-plugin-inappbrowser" />
 
 
 </widget>

--- a/config.xml
+++ b/config.xml
@@ -28,16 +28,16 @@
     <platform name="android">
         <preference name="android-minSdkVersion" value="19"/>
         <allow-intent href="market:*" />
-        <icon qualifier="ldpi" src="res/icons/android/icon-36-ldpi.png" />
-        <icon qualifier="mdpi" src="res/icons/android/icon-48-mdpi.png" />
-        <icon qualifier="hdpi" src="res/icons/android/icon-72-hdpi.png" />
-        <icon qualifier="xhdpi" src="res/icons/android/icon-96-xhdpi.png" />
-        <icon qualifier="xxhdpi" src="res/icons/android/icon-144-xxhdpi.png" />
-        <icon qualifier="xxxhdpi" src="res/icons/android/icon-192-xxxhdpi.png" />
-        <splash qualifier="ldpi" src="res/screens/android/screen-ldpi-portrait.png" />
-        <splash qualifier="mdpi" src="res/screens/android/screen-mdpi-portrait.png" />
-        <splash qualifier="hdpi" src="res/screens/android/screen-hdpi-portrait.png" />
-        <splash qualifier="xhdpi" src="res/screens/android/screen-xhdpi-portrait.png" />
+        <icon density="ldpi" src="res/icons/android/icon-36-ldpi.png" />
+        <icon density="mdpi" src="res/icons/android/icon-48-mdpi.png" />
+        <icon density="hdpi" src="res/icons/android/icon-72-hdpi.png" />
+        <icon density="xhdpi" src="res/icons/android/icon-96-xhdpi.png" />
+        <icon density="xxhdpi" src="res/icons/android/icon-144-xxhdpi.png" />
+        <icon density="xxxhdpi" src="res/icons/android/icon-192-xxxhdpi.png" />
+        <splash density="ldpi" src="res/screens/android/screen-ldpi-portrait.png" />
+        <splash density="mdpi" src="res/screens/android/screen-mdpi-portrait.png" />
+        <splash density="hdpi" src="res/screens/android/screen-hdpi-portrait.png" />
+        <splash density="xhdpi" src="res/screens/android/screen-xhdpi-portrait.png" />
     </platform>
     <platform name="ios">
         <allow-intent href="itms:*" />

--- a/config.xml
+++ b/config.xml
@@ -14,9 +14,9 @@
     <preference name="ShowSplashScreenSpinner" value="false" />
     <preference name="AutoHideSplashScreen" value="true" />
     <preference name="DisallowOverscroll" value="true" />
-    <preference name="StatusBarOverlaysWebView" value="true" />
+    <preference name="StatusBarOverlaysWebView" value="false" />
     <preference name="StatusBarStyle" value="lightcontent" />
-    <preference name="StatusBarBackgroundColor" value="#46246A" />
+    <preference name="StatusBarBackgroundColorByHexString" value="#46246A" />
     
     <allow-intent href="http://*/*" />
     <allow-intent href="https://*/*" />

--- a/www/index.html
+++ b/www/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no, minimal-ui">
+    <meta name="viewport" content="viewport-fit=cover, width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no, minimal-ui">
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black">


### PR DESCRIPTION
Phonegap CLI 8, Android API lvl 19, iOS 9+

New plugins added, will use for #9 

Old plugins not versioned, so default version is used.

Tried to fix iOS 11 status bar, now it's showing but is blue, and the other fix for it has android as black. Ignoring because minor issue, too much time already. Will make issue on github to fix later.