### PR TITLE
Edit Discussions

### DIFF
--- a/www/js/GCT.js
+++ b/www/js/GCT.js
@@ -827,7 +827,21 @@ GCTUser = {
         mainView.router.loadPage({ url: 'PostDiscussion.html?action=edit&post_guid=' + guid });
     },
     GetDiscussionEdit: function (post_guid, successCallback, errorCallback) {
-        myApp.alert("in get");
+        if (!post_guid) { return "cannot edit nothing"; } //force back? with message 
+        $$.ajax({
+            method: 'POST',
+            dataType: 'text',
+            url: GCT.GCcollabURL,
+            data: { method: "get.discussionedit", user: GCTUser.Email(), guid: post_guid, api_key: api_key_gccollab, lang: GCTLang.Lang() },
+            timeout: 12000,
+            success: function (data) {
+                data = JSON.parse(data);
+                successCallback(data);
+            },
+            error: function (jqXHR, textStatus, errorThrown) {
+                errorCallback(jqXHR, textStatus, errorThrown);
+            }
+        });
     },
 
     PostBlogPost: function (group_guid, group_public) {

--- a/www/js/GCT.js
+++ b/www/js/GCT.js
@@ -823,7 +823,8 @@ GCTUser = {
         });
     },
     EditDiscussionPost: function (obj) {
-        myApp.alert("edit option");
+        var guid = $(obj).data("guid");
+        mainView.router.loadPage({ url: 'PostDiscussion.html?action=edit&post_guid=' + guid });
     },
 
     PostBlogPost: function (group_guid, group_public) {

--- a/www/js/GCT.js
+++ b/www/js/GCT.js
@@ -802,16 +802,18 @@ GCTUser = {
     PostDiscussionPost: function (group_guid, group_public) {
         mainView.router.loadPage({ url: 'PostDiscussion.html?action=create&group_guid=' + group_guid + '&group_public=' + group_public }); 
     },
-    PostDiscussion: function (container, title, message, status, access, successCallback, errorCallback, issueCallback) {
+    PostDiscussion: function (container, topic, title, message, status, access, successCallback, errorCallback, issueCallback) {
         if (!title.en && !title.fr) { issueCallback(GCTLang.Trans("require-title")); return; }
         if (!message.en && !message.fr) { issueCallback(GCTLang.Trans("require-topic")); return; }
         if (!(title.en && message.en) && !(title.fr && message.fr)) { issueCallback(GCTLang.Trans("require-same-lang")); return; }
+        if (!container) { container = ''; }
+        if (!topic) { topic = ''; }
 
         $$.ajax({
             method: 'POST',
             dataType: 'text',
             url: GCT.GCcollabURL,
-            data: { method: 'post.discussion', user: GCTUser.Email(), title: JSON.stringify(title), message: JSON.stringify(message), container_guid: container, access: access, open: status, api_key: api_key_gccollab, lang: GCTLang.Lang() },
+            data: { method: 'post.discussion', user: GCTUser.Email(), title: JSON.stringify(title), message: JSON.stringify(message), container_guid: container, topic_guid: topic, access: access, open: status, api_key: api_key_gccollab, lang: GCTLang.Lang() },
             timeout: 12000,
             success: function (data) {
                 data = JSON.parse(data);

--- a/www/js/GCT.js
+++ b/www/js/GCT.js
@@ -800,7 +800,7 @@ GCTUser = {
     },
 
     PostDiscussionPost: function (group_guid, group_public) {
-        mainView.router.loadPage({ url: 'PostDiscussion.html?group_guid=' + group_guid + '&group_public=' + group_public }); 
+        mainView.router.loadPage({ url: 'PostDiscussion.html?action=create&group_guid=' + group_guid + '&group_public=' + group_public }); 
     },
     PostDiscussion: function (container, title, message, status, access, successCallback, errorCallback, issueCallback) {
         if (!title.en && !title.fr) { issueCallback(GCTLang.Trans("require-title")); return; }
@@ -825,6 +825,9 @@ GCTUser = {
     EditDiscussionPost: function (obj) {
         var guid = $(obj).data("guid");
         mainView.router.loadPage({ url: 'PostDiscussion.html?action=edit&post_guid=' + guid });
+    },
+    GetDiscussionEdit: function (post_guid, successCallback, errorCallback) {
+        myApp.alert("in get");
     },
 
     PostBlogPost: function (group_guid, group_public) {

--- a/www/js/GCT.js
+++ b/www/js/GCT.js
@@ -822,6 +822,9 @@ GCTUser = {
             }
         });
     },
+    EditDiscussionPost: function (obj) {
+        myApp.alert("edit option");
+    },
 
     PostBlogPost: function (group_guid, group_public) {
         if (group_guid) {
@@ -1100,7 +1103,8 @@ GCTUser = {
                         }
                         popoverHTML += '<li><a href="#" class="item-link list-button" data-guid="' + guid + '" onclick="GCTUser.Report(this);">' + GCTLang.Trans("report") + '</a></li>';
                         if( mine ){
-                            if( type == "gccollab_wire_post" ){ popoverHTML += '<li><a href="#" class="item-link list-button" data-guid="' + guid + '" onclick="GCTUser.EditWirePost(this);">' + GCTLang.Trans("edit") + '</a></li>'; }
+                            if (type == "gccollab_wire_post") { popoverHTML += '<li><a href="#" class="item-link list-button" data-guid="' + guid + '" onclick="GCTUser.EditWirePost(this);">' + GCTLang.Trans("edit") + '</a></li>'; }
+                            if (type == "gccollab_discussion_post") { popoverHTML += '<li><a href="#" class="item-link list-button" data-guid="' + guid + '" onclick="GCTUser.EditDiscussionPost(this);">' + GCTLang.Trans("edit") + '</a></li>'; }
                             if( type != "gccollab_opportunity" ){ popoverHTML += '<li><a href="#" class="item-link list-button" data-guid="' + guid + '" onclick="GCTUser.Delete(this);">' + GCTLang.Trans("delete") + '</a></li>';}
                         }
                     popoverHTML += '</ul>'

--- a/www/js/Lang.js
+++ b/www/js/Lang.js
@@ -120,6 +120,7 @@
     "issue": "Issue: ",
 
     "PostDiscussion": "Add a Discussion Topic",
+    "EditDiscussion": "Edit Discussion Topic",
     "PostBlog": "Create Blog Post",
     "english-title": "English Title",
     "french-title": "French Title",
@@ -399,6 +400,7 @@ French = {
     "issue": "Problème: ",
 
     "PostDiscussion": "Ajouter un Sujet",
+    "EditDiscussion": "Modifier la Discussion",
     "PostBlog": "Ajouter un Blogue",
     "english-title": "Titre en Anglais",
     "french-title": "Titre en Français",

--- a/www/js/gccollab.js
+++ b/www/js/gccollab.js
@@ -4371,34 +4371,55 @@ myApp.onPageInit('PostBlog', function (page) {
 });
 
 myApp.onPageInit('PostDiscussion', function (page) {
-    $$('#PostDiscussion-navbar-inner').html(GCTLang.txtGlobalNav('PostDiscussion'));
+    var action = (page.query.action) ? page.query.action : '';
     var container_guid = (page.query.group_guid) ? page.query.group_guid : '';
     var group_public = (page.query.group_public == 'false') ? $$('#PostDiscussion-public').remove() : '';
-    
-    $$('#submit-discussion').on('click', function (e) {
-        $$('#PostDiscussion-Feedback').html(''); //clears feedback message on new submit
-        var title = {}, message = {};
-        title.en = $('#english-title').val();
-        title.fr = $('#french-title').val(); 
-        message.en = $('#english-body-textarea').val();
-        message.fr = $('#french-body-textarea').val();
-        var status = $('#PostDiscussion-status').val();
-        var access = $('#PostDiscussion-access').val();
-        //container, title, message, status, access, successCallback, errorCallback, issueCallback
-        GCTUser.PostDiscussion(container_guid, title, message, status, access, function (data) {
-            if (data.result.indexOf("gccollab.ca/discussion/view/") > -1) {
-                var obj = [];
-                obj.href = data.result;
-                GCT.FireLink(obj);
-            } else {
-                myApp.alert(data.result);
-            }
+    var post_guid = (page.query.post_guid) ? page.query.post_guid : '';
+
+    if (action == "create") {
+        $$('#PostDiscussion-navbar-inner').html(GCTLang.txtGlobalNav('PostDiscussion'));
+        $$('#submit-discussion').html(GCTLang.Trans('PostDiscussion'));
+    } else if (action == "edit") {
+        $$('#PostDiscussion-navbar-inner').html(GCTLang.txtGlobalNav('EditDiscussion'));
+        $$('#submit-discussion').html(GCTLang.Trans('EditDiscussion'));
+        GCTUser.GetDiscussionEdit(post_guid, function (data) {
+            var discussion = data.result;
+            //set text into form fields
+            //$(content).hide().appendTo('#newsfeed-all').fadeIn(1000);
         }, function (jqXHR, textStatus, errorThrown) {
             console.log(jqXHR, textStatus, errorThrown);
-        }, function (feedback) {
-            var feedbackmsg = '<p class="card-content-inner" style="padding-top: 0;padding-bottom: 0;" id="PostDiscussion-Feedback">' + GCTLang.Trans('issue') + feedback + '</p>';
-            $(feedbackmsg).hide().appendTo('#PostDiscussion-Feedback').fadeIn(500);
         });
+    }
+    
+    $$('#submit-discussion').on('click', function (e) {
+        if (action == "create") {
+            $$('#PostDiscussion-Feedback').html(''); //clears feedback message on new submit
+            var title = {}, message = {};
+            title.en = $('#english-title').val();
+            title.fr = $('#french-title').val();
+            message.en = $('#english-body-textarea').val();
+            message.fr = $('#french-body-textarea').val();
+            var status = $('#PostDiscussion-status').val();
+            var access = $('#PostDiscussion-access').val();
+            
+            GCTUser.PostDiscussion(container_guid, title, message, status, access, function (data) {
+                if (data.result.indexOf("gccollab.ca/discussion/view/") > -1) {
+                    var obj = [];
+                    obj.href = data.result;
+                    GCT.FireLink(obj);
+                } else {
+                    myApp.alert(data.result);
+                }
+            }, function (jqXHR, textStatus, errorThrown) {
+                console.log(jqXHR, textStatus, errorThrown);
+            }, function (feedback) {
+                var feedbackmsg = '<p class="card-content-inner" style="padding-top: 0;padding-bottom: 0;" id="PostDiscussion-Feedback">' + GCTLang.Trans('issue') + feedback + '</p>';
+                $(feedbackmsg).hide().appendTo('#PostDiscussion-Feedback').fadeIn(500);
+            });
+        } else if (action == "edit") {
+            myApp.alert("Edit Submit Placeholder");
+        }
+        
     });
 });
  

--- a/www/js/gccollab.js
+++ b/www/js/gccollab.js
@@ -4384,6 +4384,7 @@ myApp.onPageInit('PostDiscussion', function (page) {
         $$('#submit-discussion').html(GCTLang.Trans('EditDiscussion'));
         GCTUser.GetDiscussionEdit(post_guid, function (data) {
             var discussion = data.result;
+            container_guid = discussion.container_guid;
             $$('input#english-title').val(discussion.title.en);
             $$('input#french-title').val(discussion.title.fr);
             $$('#english-body-textarea').val(discussion.description.en);
@@ -4395,33 +4396,30 @@ myApp.onPageInit('PostDiscussion', function (page) {
     }
     
     $$('#submit-discussion').on('click', function (e) {
-        if (action == "create") {
-            $$('#PostDiscussion-Feedback').html(''); //clears feedback message on new submit
-            var title = {}, message = {};
-            title.en = $('#english-title').val();
-            title.fr = $('#french-title').val();
-            message.en = $('#english-body-textarea').val();
-            message.fr = $('#french-body-textarea').val();
-            var status = $('#PostDiscussion-status').val();
-            var access = $('#PostDiscussion-access').val();
+        
+        $$('#PostDiscussion-Feedback').html(''); //clears feedback message on new submit
+        var title = {}, message = {};
+        title.en = $('#english-title').val();
+        title.fr = $('#french-title').val();
+        message.en = $('#english-body-textarea').val();
+        message.fr = $('#french-body-textarea').val();
+        var status = $('#PostDiscussion-status').val();
+        var access = $('#PostDiscussion-access').val();
             
-            GCTUser.PostDiscussion(container_guid, title, message, status, access, function (data) {
-                if (data.result.indexOf("gccollab.ca/discussion/view/") > -1) {
-                    var obj = [];
-                    obj.href = data.result;
-                    GCT.FireLink(obj);
-                } else {
-                    myApp.alert(data.result);
-                }
-            }, function (jqXHR, textStatus, errorThrown) {
-                console.log(jqXHR, textStatus, errorThrown);
-            }, function (feedback) {
-                var feedbackmsg = '<p class="card-content-inner" style="padding-top: 0;padding-bottom: 0;" id="PostDiscussion-Feedback">' + GCTLang.Trans('issue') + feedback + '</p>';
-                $(feedbackmsg).hide().appendTo('#PostDiscussion-Feedback').fadeIn(500);
-            });
-        } else if (action == "edit") {
-            myApp.alert("Edit Submit Placeholder");
-        }
+        GCTUser.PostDiscussion(container_guid, post_guid, title, message, status, access, function (data) {
+            if (data.result.indexOf("gccollab.ca/discussion/view/") > -1) {
+                var obj = [];
+                obj.href = data.result;
+                GCT.FireLink(obj);
+            } else {
+                myApp.alert(data.result);
+            }
+        }, function (jqXHR, textStatus, errorThrown) {
+            console.log(jqXHR, textStatus, errorThrown);
+        }, function (feedback) {
+            var feedbackmsg = '<p class="card-content-inner" style="padding-top: 0;padding-bottom: 0;" id="PostDiscussion-Feedback">' + GCTLang.Trans('issue') + feedback + '</p>';
+            $(feedbackmsg).hide().appendTo('#PostDiscussion-Feedback').fadeIn(500);
+        });
         
     });
 });

--- a/www/js/gccollab.js
+++ b/www/js/gccollab.js
@@ -4373,19 +4373,22 @@ myApp.onPageInit('PostBlog', function (page) {
 myApp.onPageInit('PostDiscussion', function (page) {
     var action = (page.query.action) ? page.query.action : '';
     var container_guid = (page.query.group_guid) ? page.query.group_guid : '';
-    var group_public = (page.query.group_public == 'false') ? $$('#PostDiscussion-public').remove() : '';
     var post_guid = (page.query.post_guid) ? page.query.post_guid : '';
 
     if (action == "create") {
         $$('#PostDiscussion-navbar-inner').html(GCTLang.txtGlobalNav('PostDiscussion'));
         $$('#submit-discussion').html(GCTLang.Trans('PostDiscussion'));
+        if (page.query.group_public == 'false') { $$('#PostDiscussion-public').remove(); }
     } else if (action == "edit") {
         $$('#PostDiscussion-navbar-inner').html(GCTLang.txtGlobalNav('EditDiscussion'));
         $$('#submit-discussion').html(GCTLang.Trans('EditDiscussion'));
         GCTUser.GetDiscussionEdit(post_guid, function (data) {
             var discussion = data.result;
-            //set text into form fields
-            //$(content).hide().appendTo('#newsfeed-all').fadeIn(1000);
+            $$('input#english-title').val(discussion.title.en);
+            $$('input#french-title').val(discussion.title.fr);
+            $$('#english-body-textarea').val(discussion.description.en);
+            $$('#french-body-textarea').val(discussion.description.fr);
+            if (!discussion.group.public) { $$('#PostDiscussion-public').remove(); }
         }, function (jqXHR, textStatus, errorThrown) {
             console.log(jqXHR, textStatus, errorThrown);
         });


### PR DESCRIPTION
closes #174 

Option in the MoreOptions function, to have the popover show edit when user is owner, and post is a discussion.

EditDiscussion function will redirect to the PostDiscussion page with needed variables. Action = Edit, and Post_GUID

PostDiscussion page will check  action. If edit, will change title and submit to EditDiscussion, and hit GetDiscussionEdit function, to get discussion info to fill form fields.

GetDiscussionEdit AJAX call to grab the discussion post's full information.

Added topic_guid to PostDiscussion function and AJAX. Correctly saves edit now.