### PR TITLE
Home Redesign

### DIFF
--- a/www/home.html
+++ b/www/home.html
@@ -1,8 +1,15 @@
-<div data-page="home" class="page navbar-fixed">
+<div data-page="home" class="page navbar-fixed with-subnavbar">
 
-  <div class="navbar main-navbar">
-    <div id="home-navbar-inner" class="navbar-inner"> </div>
-  </div>
+    <div class="navbar main-navbar">
+        <div id="home-navbar-inner" class="navbar-inner"> </div>
+        <div class="subnavbar">
+            <div class="buttons-row">
+                <a href="#tab-newsfeed" class="button active tab-link" data-translate="newsfeed">Newsfeed</a>
+                <a href="#tab-wire" class="button tab-link" data-translate="the-wire">The Wire</a>
+                <a href="#tab-blogs" class="button tab-link" data-translate="blogs">Blogs</a>
+            </div>
+        </div>
+    </div>
 
     <div class="toolbar toolbar-bottom">
         <div class="toolbar-inner">
@@ -11,43 +18,43 @@
         </div>
     </div>
 
-  <div class="page-content hide-bars-on-scroll pull-to-refresh-content" style="overflow-x: hidden;">
+  <div class="page-content hide-bars-on-scroll pull-to-refresh-content with-subnavbar" style="overflow-x: hidden;">
     <div class="pull-to-refresh-layer">
       <div class="preloader"></div>
       <div class="pull-to-refresh-arrow"></div>
     </div>
 
-    <div class="content-block small">
-      <div class="row">
-        <div class="col-66"><h2 class="no-margin" data-translate="the-wire">The Wire</h2></div>
-        <div class="col-33"><a href="wire.html" class="button button-fill pull-right" data-translate="view-all">VIEW ALL</a></div>
-      </div>
-    </div>
-    <div class="swiper-container swiper-wires context home-section">
-      <div class="swiper-wrapper" id="GCcollabUserWireContent"><span class="loading" data-translate="loading">Loading...</span></div>
-      <div class="swiper-pagination"></div>
-    </div>
-
-    <div class="content-block small">
-      <div class="row">
-        <div class="col-66"><h2 class="no-margin" data-translate="newsfeed">Newsfeed</h2></div>
-        <div class="col-33"><a href="newsfeed.html" class="button button-fill pull-right" data-translate="view-all">VIEW ALL</a></div>
-      </div>
-    </div>
-    <div class="swiper-container swiper-newsfeed context home-section">
-      <div class="swiper-wrapper" id="GCcollabUserNewsfeedContent"><span class="loading" data-translate="loading">Loading...</span></div>
-      <div class="swiper-pagination"></div>
-    </div>
-
-    <div class="content-block small">
-      <div class="row">
-        <div class="col-66"><h2 class="no-margin" data-translate="blogs">Blogs</h2></div>
-        <div class="col-33"><a href="blog.html" class="button button-fill pull-right" data-translate="view-all">VIEW ALL</a></div>
-      </div>
-    </div>
-    <div class="swiper-container swiper-blogs context home-section">
-      <div class="swiper-wrapper" id="GCcollabUserBlogContent"><span class="loading" data-translate="loading">Loading...</span></div>
-      <div class="swiper-pagination"></div>
+    <div class="tabs">
+        <div id="tab-newsfeed" class="tab active">
+            <div class="content-block small">
+                <div class="row">
+                    <div class="col-66"><h2 class="no-margin" data-translate="newsfeed">Newsfeed</h2></div>
+                    <div class="col-33"><a href="newsfeed.html" class="button button-fill pull-right" data-translate="view-all">VIEW ALL</a></div>
+                </div>
+            </div>
+            <div id="home-newsfeed" class="context"></div>
+            <a id="home-newsfeed-more" class="button button-big button-fill" data-translate="view-more">VIEW MORE</a>
+        </div>
+        <div id="tab-wire" class="tab">
+            <div class="content-block small">
+                <div class="row">
+                    <div class="col-66"><h2 class="no-margin" data-translate="the-wire">The Wire</h2></div>
+                    <div class="col-33"><a href="wire.html" class="button button-fill pull-right" data-translate="view-all">VIEW ALL</a></div>
+                </div>
+            </div>
+            <div id="home-wire" class="context"></div>
+            <a id="home-wire-more" class="button button-big button-fill" data-translate="view-more">VIEW MORE</a>
+        </div>
+        <div id="tab-blogs" class="tab">
+            <div class="content-block small">
+                <div class="row">
+                    <div class="col-66"><h2 class="no-margin" data-translate="blogs">Blogs</h2></div>
+                    <div class="col-33"><a href="blog.html" class="button button-fill pull-right" data-translate="view-all">VIEW ALL</a></div>
+                </div>
+            </div>
+            <div id="home-blogs" class="context"></div>
+            <a id="home-blogs-more" class="button button-big button-fill" data-translate="view-more">VIEW MORE</a>
+        </div>
     </div>
 
     <div class="content-block">

--- a/www/homeOld.html
+++ b/www/homeOld.html
@@ -1,0 +1,83 @@
+<div data-page="homeOld" class="page navbar-fixed">
+
+  <div class="navbar main-navbar">
+    <div id="home-navbar-inner" class="navbar-inner"> </div>
+  </div>
+
+    <div class="toolbar toolbar-bottom">
+        <div class="toolbar-inner">
+            <div class="left sliding"><a href="#" class="link back" aria-label="Back Button"><i class="fa fa-arrow-circle-o-left fa-2x"></i></a></div>
+            <div class="right sliding"><a id="home-actions" href="#" class="link open-popover" data-popover=".popover-actions" aria-label="Create a new Post Menu Options"><i class="fa fa-plus fa-2x"></i></a></div>
+        </div>
+    </div>
+
+  <div class="page-content hide-bars-on-scroll pull-to-refresh-content" style="overflow-x: hidden;">
+    <div class="pull-to-refresh-layer">
+      <div class="preloader"></div>
+      <div class="pull-to-refresh-arrow"></div>
+    </div>
+
+    <div class="content-block small">
+      <div class="row">
+        <div class="col-66"><h2 class="no-margin" data-translate="the-wire">The Wire</h2></div>
+        <div class="col-33"><a href="wire.html" class="button button-fill pull-right" data-translate="view-all">VIEW ALL</a></div>
+      </div>
+    </div>
+    <div class="swiper-container swiper-wires context home-section">
+      <div class="swiper-wrapper" id="GCcollabUserWireContent"><span class="loading" data-translate="loading">Loading...</span></div>
+      <div class="swiper-pagination"></div>
+    </div>
+
+    <div class="content-block small">
+      <div class="row">
+        <div class="col-66"><h2 class="no-margin" data-translate="newsfeed">Newsfeed</h2></div>
+        <div class="col-33"><a href="newsfeed.html" class="button button-fill pull-right" data-translate="view-all">VIEW ALL</a></div>
+      </div>
+    </div>
+    <div class="swiper-container swiper-newsfeed context home-section">
+      <div class="swiper-wrapper" id="GCcollabUserNewsfeedContent"><span class="loading" data-translate="loading">Loading...</span></div>
+      <div class="swiper-pagination"></div>
+    </div>
+
+    <div class="content-block small">
+      <div class="row">
+        <div class="col-66"><h2 class="no-margin" data-translate="blogs">Blogs</h2></div>
+        <div class="col-33"><a href="blog.html" class="button button-fill pull-right" data-translate="view-all">VIEW ALL</a></div>
+      </div>
+    </div>
+    <div class="swiper-container swiper-blogs context home-section">
+      <div class="swiper-wrapper" id="GCcollabUserBlogContent"><span class="loading" data-translate="loading">Loading...</span></div>
+      <div class="swiper-pagination"></div>
+    </div>
+
+    <div class="content-block">
+      <h2 class="center" data-translate="connect-with-us">Connect With Us</h2>
+      <ul class="socials">
+        <li><a href="https://github.com/gctools-outilsgc/gccollab" class="gh external"><i class="fa fa-github"></i></a></li>
+        <li><a href="https://twitter.com/gccollab" class="tw external"><i class="fa fa-twitter"></i></a></li>
+        <li><a href="mailto:jeff.outram@tbs-sct.gc.ca" class="env external"><i class="fa fa-envelope"></i></a></li>
+      </ul>
+    </div>
+
+    <hr />
+
+    <div class="content-block center">
+      <span class="" data-translate="credit">This App Brought To You By the GCTools Team</span>
+    </div>
+  </div>
+  
+    <div class="popover popover-actions">
+        <div class="popover-angle"></div>
+        <div class="popover-inner">
+            <div class="list-block">
+                <ul>
+                    <!-- <a onclick="GCTUser.NewMessage();"><i class="fa fa-envelope"></i></a> -->
+                    <!-- <a onclick="GCTUser.NewBlogPost();"><i class="fa fa-pencil-square-o"></i></a> -->
+                    <li><a href="#" onclick="GCTUser.PostWirePost();" class="list-button item-link close-popover"><i class="fa fa-feed"></i>  <span data-translate="create-wire">Create a new Wire post</span> </a></li>
+                    <li><a href="#" onclick="GCTUser.PostBlogPost();" class="list-button item-link close-popover"><i class="fa fa-pencil-square-o"></i>  <span data-translate="PostBlog">Create a new Blog</span> </a></li>
+                </ul>
+            </div>
+        </div>
+    </div>
+</div>
+

--- a/www/js/gccollab.js
+++ b/www/js/gccollab.js
@@ -1008,6 +1008,77 @@ myApp.onPageInit('sign-in', function (page) {
 
 myApp.onPageInit('home', function (page) {
     $$('#home-navbar-inner').html(GCTLang.txtGlobalNav('gccollab'));
+    var limit = 12;
+    var offset = 0;
+
+    GCTUser.GetNewsfeed(limit, offset, function (data) {
+        var newsfeed = data.result;
+
+        if (newsfeed.length > 0) {
+            $.each(newsfeed, function (key, value) {
+                var content = GCTEach.Newsfeed(value);
+
+                //### I think fades cause significant performance hits on devices when we have 30 concurrent ones like we do.
+                //### The below makes it so that it only fades the first, visible, post in the list.
+                if (key == 0) {
+                    $(content).hide().appendTo('#home-newsfeed').fadeIn(1000);
+                } else {
+                    $(content).appendTo('#home-newsfeed');
+                }
+            });
+        } else {
+            $(noContent).hide().appendTo('#home-newsfeed').fadeIn(1000);
+        }
+        
+
+    }, function (jqXHR, textStatus, errorThrown) {
+        console.log(jqXHR, textStatus, errorThrown);
+        }
+    );
+
+    GCTUser.GetWires(limit, offset, '', function (data) {
+        var wires = data.result;
+
+        if (wires.length > 0) {
+            $.each(wires, function (key, value) {
+                var content = GCTEach.Wire(value);
+                if (key == 0) {
+                    $(content).hide().appendTo('#home-wire').fadeIn(1000);
+                } else {
+                    $(content).appendTo('#home-wire');
+                }
+            });
+        } else {
+            $(noContent).hide().appendTo('#home-wire').fadeIn(1000);
+        }
+
+    }, function (jqXHR, textStatus, errorThrown) {
+        console.log(jqXHR, textStatus, errorThrown);
+        }
+    );
+
+    GCTUser.GetBlogs(limit, offset, "", function (data) {
+        var blogs = data.result;
+        if (blogs.length > 0) {
+            $.each(blogs, function (key, value) {
+                var content = GCTEach.Blog(value);
+                if (key == 0) {
+                    $(content).hide().appendTo('#home-blogs').fadeIn(1000);
+                } else {
+                    $(content).appendTo('#home-blogs');
+                }
+            });
+        } else {
+            $(noContent).hide().appendTo('#home-blogs').fadeIn(1000);
+        }
+    }, function (jqXHR, textStatus, errorThrown) {
+        console.log(jqXHR, textStatus, errorThrown);
+    });
+
+});
+
+myApp.onPageInit('homeOld', function (page) {
+    $$('#home-navbar-inner').html(GCTLang.txtGlobalNav('gccollab'));
 
     var limit = 15;
     var offset = 0;

--- a/www/js/gccollab.js
+++ b/www/js/gccollab.js
@@ -1010,71 +1010,146 @@ myApp.onPageInit('home', function (page) {
     $$('#home-navbar-inner').html(GCTLang.txtGlobalNav('gccollab'));
     var limit = 12;
     var offset = 0;
+    var offset_wires = 0;
+    var offset_newsfeed = 0;
+    var offset_blogs = 0;
+    var loaded_wire = false;
+    var loaded_blog = false;
 
     GCTUser.GetNewsfeed(limit, offset, function (data) {
         var newsfeed = data.result;
-
+        var content = '';
         if (newsfeed.length > 0) {
             $.each(newsfeed, function (key, value) {
-                var content = GCTEach.Newsfeed(value);
+                content = GCTEach.Newsfeed(value);
+                $(content).appendTo('#home-newsfeed');
+            });
+        }
+        if (newsfeed.length < limit) {
+            content = endOfContent;
+            $(content).appendTo('#home-newsfeed');
+            $('#home-newsfeed-more').hide();
+        }
+    }, function (jqXHR, textStatus, errorThrown) {
+        console.log(jqXHR, textStatus, errorThrown);
+        }
+    );
+    $$('#home-newsfeed-more').on('click', function (e) {
+        GCTUser.GetNewsfeed(limit, offset_newsfeed + limit, function (data) {
+            var newsfeed = data.result;
 
-                //### I think fades cause significant performance hits on devices when we have 30 concurrent ones like we do.
-                //### The below makes it so that it only fades the first, visible, post in the list.
-                if (key == 0) {
-                    $(content).hide().appendTo('#home-newsfeed').fadeIn(1000);
-                } else {
+            if (newsfeed.length > 0) {
+                $.each(newsfeed, function (key, value) {
+                    var content = GCTEach.Newsfeed(value);
                     $(content).appendTo('#home-newsfeed');
-                }
-            });
-        } else {
-            $(noContent).hide().appendTo('#home-newsfeed').fadeIn(1000);
+                });
+            }
+            if (newsfeed.length < limit) {
+                content = endOfContent;
+                $(content).appendTo('#home-newsfeed');
+                $('#home-newsfeed-more').hide();
+            }
+            offset_newsfeed += limit;
+        }, function (jqXHR, textStatus, errorThrown) {
+            console.log(jqXHR, textStatus, errorThrown);
         }
-        
-
-    }, function (jqXHR, textStatus, errorThrown) {
-        console.log(jqXHR, textStatus, errorThrown);
-        }
-    );
-
-    GCTUser.GetWires(limit, offset, '', function (data) {
-        var wires = data.result;
-
-        if (wires.length > 0) {
-            $.each(wires, function (key, value) {
-                var content = GCTEach.Wire(value);
-                if (key == 0) {
-                    $(content).hide().appendTo('#home-wire').fadeIn(1000);
-                } else {
-                    $(content).appendTo('#home-wire');
-                }
-            });
-        } else {
-            $(noContent).hide().appendTo('#home-wire').fadeIn(1000);
-        }
-
-    }, function (jqXHR, textStatus, errorThrown) {
-        console.log(jqXHR, textStatus, errorThrown);
-        }
-    );
-
-    GCTUser.GetBlogs(limit, offset, "", function (data) {
-        var blogs = data.result;
-        if (blogs.length > 0) {
-            $.each(blogs, function (key, value) {
-                var content = GCTEach.Blog(value);
-                if (key == 0) {
-                    $(content).hide().appendTo('#home-blogs').fadeIn(1000);
-                } else {
-                    $(content).appendTo('#home-blogs');
-                }
-            });
-        } else {
-            $(noContent).hide().appendTo('#home-blogs').fadeIn(1000);
-        }
-    }, function (jqXHR, textStatus, errorThrown) {
-        console.log(jqXHR, textStatus, errorThrown);
+        );
     });
 
+    $$('#tab-wire').on('show', function (e) {
+        if (!loaded_wire) {
+            loaded_wire = true;
+            GCTUser.GetWires(limit, offset, '', function (data) {
+                var wires = data.result;
+                var imgs = [];
+                var content = '';
+                if (wires.length > 0) {
+                    $.each(wires, function (key, value) {
+                        content = GCTEach.Wire(value);
+                        $(content).hide().appendTo('#home-wire').fadeIn(1000);
+                    });
+                }
+                if (wires.length < limit) {
+                    content = endOfContent;
+                    $(content).appendTo('#home-wire');
+                    $('#home-wire-more').hide();
+                }
+                
+            }, function (jqXHR, textStatus, errorThrown) {
+                console.log(jqXHR, textStatus, errorThrown);
+            });
+        }
+    });
+    $$('#home-wire-more').on('click', function (e) {
+        GCTUser.GetWires(limit, offset_wires + limit, '', function (data) {
+            var wires = data.result;
+            var content = '';
+            if (wires.length > 0) {
+                $.each(wires, function (key, value) {
+                    content = GCTEach.Wire(value);
+                    $(content).hide().appendTo('#home-wire').fadeIn(1000);
+                });
+            }
+            if (wires.length < limit) {
+                content = endOfContent;
+                $(content).appendTo('#home-wire');
+                $('#home-wire-more').hide();
+            }
+            offset_wires += limit;
+        }, function (jqXHR, textStatus, errorThrown) {
+            console.log(jqXHR, textStatus, errorThrown);
+        });
+    });
+
+    $$('#tab-blogs').on('show', function (e) {
+        if (!loaded_blog) {
+            loaded_blog = true;
+            GCTUser.GetBlogs(limit, offset, "", function (data) {
+                var blogs = data.result;
+                var content = '';
+                if (blogs.length > 0) {
+                    $.each(blogs, function (key, value) {
+                        content = GCTEach.Blog(value);
+                        $(content).appendTo('#home-blogs');
+                    });
+                } 
+                if (blogs.length < limit) {
+                    content = endOfContent;
+                    $(content).appendTo('#home-blogs');
+                    $('#home-blogs-more').hide();
+                }
+            }, function (jqXHR, textStatus, errorThrown) {
+                console.log(jqXHR, textStatus, errorThrown);
+            });
+        }
+    });
+    $$('#home-blogs-more').on('click', function (e) {
+        GCTUser.GetBlogs(limit, offset_blogs + limit, "", function (data) {
+            var blogs = data.result;
+            var content = '';
+            if (blogs.length > 0) {
+                $.each(blogs, function (key, value) {
+                    content = GCTEach.Blog(value);
+                    $(content).appendTo('#home-blogs').fadeIn(1000);
+                });
+            } 
+            if (blogs.length < limit) {
+                content = endOfContent;
+                $(content).appendTo('#home-blogs');
+                $('#home-blogs-more').hide();
+            }
+            offset_blogs += limit;
+        }, function (jqXHR, textStatus, errorThrown) {
+            console.log(jqXHR, textStatus, errorThrown);
+        });
+    });
+
+    var refreshHome = $$(page.container).find('.pull-to-refresh-content');
+    refreshHome.on('refresh', function (e) {
+        console.log("refresh");
+        //referesh placeholder
+        myApp.pullToRefreshDone();
+    });
 });
 
 myApp.onPageInit('homeOld', function (page) {
@@ -2537,7 +2612,7 @@ myApp.onPageInit('blog', function (page) {
                 });
             } else {
                 $('#blogs-all-more').hide();
-                $(noMatches).hide().appendTo('#blogs-all').fadeIn(1000);
+                $(endOfContent).hide().appendTo('#blogs-all').fadeIn(1000);
             }
             blogsMoreOffset += limit;
         }, function(jqXHR, textStatus, errorThrown){


### PR DESCRIPTION
Removed swiping content home design due to accessibility and user experience. 

New one is consistent with other content list pages. 
3 Tabs, newsfeed, wire, blogs. Same content as before.

PullToRefresh is a placeholder.

Old Home saved, as some users did like it, so may implement a page for users to use the old home. Or trash it later.

![newhome](https://user-images.githubusercontent.com/34379222/38830517-94906c86-418a-11e8-98bd-89ecd425da62.PNG)
