### PR TITLE
Home Focus Testing

### DIFF
--- a/www/home.html
+++ b/www/home.html
@@ -28,7 +28,7 @@
         <div id="tab-home-newsfeed" class="tab active">
             <div class="content-block small">
                 <div class="row">
-                    <div class="col-66"><h2 class="no-margin" data-translate="newsfeed">Newsfeed</h2></div>
+                    <div class="col-66"><h2 class="no-margin" data-translate="newsfeed" tabindex="0" id="tabheader-home-newsfeed">Newsfeed</h2></div>
                 </div>
             </div>
             <div id="content-home-newsfeed" class="context"></div>
@@ -37,7 +37,7 @@
         <div id="tab-home-wire" class="tab">
             <div class="content-block small">
                 <div class="row">
-                    <div class="col-66"><h2 class="no-margin" data-translate="the-wire">The Wire</h2></div>
+                    <div class="col-66"><h2 class="no-margin" data-translate="the-wire" tabindex="0" id="tabheader-home-wires">The Wire</h2></div>
                     <div class="col-33"><a href="wire.html" class="button button-fill pull-right" data-translate="view-all">VIEW ALL</a></div>
                 </div>
             </div>
@@ -47,7 +47,7 @@
         <div id="tab-home-blogs" class="tab">
             <div class="content-block small">
                 <div class="row">
-                    <div class="col-66"><h2 class="no-margin" data-translate="blogs">Blogs</h2></div>
+                    <div class="col-66"><h2 class="no-margin" data-translate="blogs" tabindex="0" id="tabheader-home-blogs">Blogs</h2></div>
                     <div class="col-33"><a href="blog.html" class="button button-fill pull-right" data-translate="view-all">VIEW ALL</a></div>
                 </div>
             </div>

--- a/www/home.html
+++ b/www/home.html
@@ -1,8 +1,8 @@
 <div data-page="home" class="page navbar-fixed with-subnavbar">
 
     <div class="navbar main-navbar">
-        <div id="home-navbar-inner" class="navbar-inner"> </div>
-        <div class="subnavbar">
+        <div id="home-navbar-inner" class="navbar-inner" role="navigation" data-translate-target="aria-label" data-translate="navigation-bar"> </div>
+        <div class="subnavbar" role="navigation" data-translate-target="aria-label" data-translate="tab-bar">
             <div class="buttons-row">
                 <a href="#tab-home-newsfeed" class="button active tab-link" data-translate="newsfeed">Newsfeed</a>
                 <a href="#tab-home-wire" class="button tab-link" data-translate="the-wire">The Wire</a>
@@ -11,7 +11,7 @@
         </div>
     </div>
 
-    <div class="toolbar toolbar-bottom">
+    <div class="toolbar toolbar-bottom" role="navigation" data-translate-target="aria-label" data-translate="toolbar">
         <div class="toolbar-inner">
             <div class="left sliding"><a href="#" class="link back" aria-label="Back Button"><i class="fa fa-arrow-circle-o-left fa-2x"></i></a></div>
             <div class="right sliding"><a id="home-actions" href="#" class="link open-popover" data-popover=".popover-actions" aria-label="Create a new Post Menu Options"><i class="fa fa-plus fa-2x"></i></a></div>

--- a/www/index.html
+++ b/www/index.html
@@ -221,7 +221,7 @@
         <div class="navbar">
           <div class="navbar-inner">
             <div class="left"><a href="#" class="link close-panel"><i class="icon icon-close"></i></a></div>
-            <div class="center" data-translate="message-centre">Message Centre</div>
+            <div class="center" id="message-panel" tabindex="0" data-translate="message-centre">Message Centre</div>
             <div class="right"><a href="#" id="colleague-requests" class="link icon-only"><i class="fa fa-users badge-wrapper"></i></a></div>
           </div>
         </div>

--- a/www/index.html
+++ b/www/index.html
@@ -47,13 +47,11 @@
 <div class="panel-overlay"></div>
 
 <div class="panel panel-left panel-cover sidebar">
-    <div class="buttonbar row no-gutter">
-        <a id="logoutBtn" class="button button-fill col-100" data-translate="logout">Logout</a>
-    </div>
   <div class="view">
     <div class=" ">
       <div data-page="panel-left" class="sidemenu leftmenusmall gradient">
           <a href="#" class="link close-panel" aria-label="Close Panel" style="position: absolute !important; clip: rect(1px, 1px, 1px, 1px);" tabindex="0"><i class="icon icon-close"></i></a>
+          <div class="center" id="menu-panel" style="position: absolute !important; clip: rect(1px, 1px, 1px, 1px);" tabindex="0" data-translate="main-menu">Main Menu</div>
         <div class="item-content userprofile">
           <div class="item-media"><a href="#" class="item-link close-panel" onclick="ShowProfile();"><img src="" width="44" alt="" id="imgUserProfilePic"/></a></div>
           <div class="item-inner">
@@ -209,6 +207,9 @@
       </div>
     </div>
   </div>
+    <div class="buttonbar row no-gutter">
+        <a id="logoutBtn" class="button button-fill col-100" data-translate="logout">Logout</a>
+    </div>
 </div>
 
 <div class="panel panel-right panel-cover sidebar">

--- a/www/js/GCT.js
+++ b/www/js/GCT.js
@@ -406,9 +406,9 @@ GCTLang = {
         return content;
     },
     txtGlobalNav: function (title) {
-        var content = '<div class="left sliding"><a href="#" data-panel="left" class="open-panel link icon-only" aria-label="Button to open Site Navigation Menu"><i class="icon icon-bars"></i></a></div>' +
-            '<div class="center" id="'+title+'">' + GCTLang.Trans(title) + '</div>' +
-            '<div class="right sliding"><a href="#" data-panel="right" class="open-panel link icon-only" aria-label="Button to open Notification Panel"><i class="fa fa-bell badge-wrapper"></i></a></div>';
+        var content = '<div class="left sliding"><a href="#" data-panel="left" class="open-panel link icon-only" aria-label="Open Navigation Menu"><i class="icon icon-bars"></i></a></div>' +
+            '<div class="center" id="' + title +'" tabindex="0">' + GCTLang.Trans(title) + '</div>' +
+            '<div class="right sliding"><a href="#" data-panel="right" class="open-panel link icon-only" aria-label="Open Notification Panel"><i class="fa fa-bell badge-wrapper"></i></a></div>';
         return content;
     },
     txtFocusMessage: function (id) {

--- a/www/js/GCT.js
+++ b/www/js/GCT.js
@@ -406,7 +406,8 @@ GCTLang = {
         return content;
     },
     txtGlobalNav: function (title) {
-        var content = '<div class="left sliding"><a href="#" data-panel="left" class="open-panel link icon-only" aria-label="Open Navigation Menu"><i class="icon icon-bars"></i></a></div>' +
+        var content = '<div class="center" id="page-' + GCTLang.Trans(title) + '" style="position: absolute !important; clip: rect(1px, 1px, 1px, 1px);" tabindex="0" >' + GCTLang.Trans("page") + GCTLang.Trans(title) + '</div>' +
+            '<div class="left sliding"><a href="#" data-panel="left" class="open-panel link icon-only" aria-label="Open Navigation Menu"><i class="icon icon-bars"></i></a></div>' +
             '<div class="center" id="' + title +'" tabindex="0">' + GCTLang.Trans(title) + '</div>' +
             '<div class="right sliding"><a href="#" data-panel="right" class="open-panel link icon-only" aria-label="Open Notification Panel"><i class="fa fa-bell badge-wrapper"></i></a></div>';
         return content;

--- a/www/js/GCT.js
+++ b/www/js/GCT.js
@@ -406,7 +406,7 @@ GCTLang = {
         return content;
     },
     txtGlobalNav: function (title) {
-        var content = '<div class="center" id="page-' + GCTLang.Trans(title) + '" style="position: absolute !important; clip: rect(1px, 1px, 1px, 1px);" tabindex="0" >' + GCTLang.Trans("page") + GCTLang.Trans(title) + '</div>' +
+        var content = '<div class="center" id="page-' + title + '" style="position: absolute !important; clip: rect(1px, 1px, 1px, 1px);" tabindex="0" >' + GCTLang.Trans("page") + GCTLang.Trans(title) + '</div>' +
             '<div class="left sliding"><a href="#" data-panel="left" class="open-panel link icon-only" aria-label="Open Navigation Menu"><i class="icon icon-bars"></i></a></div>' +
             '<div class="center" id="' + title +'" tabindex="0">' + GCTLang.Trans(title) + '</div>' +
             '<div class="right sliding"><a href="#" data-panel="right" class="open-panel link icon-only" aria-label="Open Notification Panel"><i class="fa fa-bell badge-wrapper"></i></a></div>';

--- a/www/js/Lang.js
+++ b/www/js/Lang.js
@@ -282,6 +282,7 @@
     "more-options-opened": "More Options Menu Opened.",
     "more-tab-menu-opened": "More Tabs List",
     "main-menu": "Main Menu",
+    "page": "Page ",
    
     "step1":"Step 1",
     "step2":"Step 2",
@@ -661,6 +662,7 @@ French = {
     "more-options-opened": "Plus d'options menu ouvert.",
     "more-tab-menu-opened": "Plus de liste d'onglets",
     "main-menu": "Menu Principal",
+    "page": "Page ",
     
     "step1":"Étape 1",
     "step2":"Étape 2",

--- a/www/js/Lang.js
+++ b/www/js/Lang.js
@@ -283,6 +283,9 @@
     "more-tab-menu-opened": "More Tabs List",
     "main-menu": "Main Menu",
     "page": "Page ",
+    "navigation-bar": "Navigation Bar",
+    "tab-bar": "Tab Bar",
+    "toolbar": "Toolbar",
    
     "step1":"Step 1",
     "step2":"Step 2",
@@ -663,6 +666,9 @@ French = {
     "more-tab-menu-opened": "Plus de liste d'onglets",
     "main-menu": "Menu Principal",
     "page": "Page ",
+    "navigation-bar": "barre de navigation",
+    "tab-bar": "barre d'onglets",
+    "toolbar": "barre d'outils",
     
     "step1":"Étape 1",
     "step2":"Étape 2",

--- a/www/js/Lang.js
+++ b/www/js/Lang.js
@@ -281,6 +281,7 @@
     "content-loaded": "New content appended to page.",
     "more-options-opened": "More Options Menu Opened.",
     "more-tab-menu-opened": "More Tabs List",
+    "main-menu": "Main Menu",
    
     "step1":"Step 1",
     "step2":"Step 2",
@@ -659,6 +660,7 @@ French = {
     "content-loaded": "Nouveau contenu ajouté à la page.",
     "more-options-opened": "Plus d'options menu ouvert.",
     "more-tab-menu-opened": "Plus de liste d'onglets",
+    "main-menu": "Menu Principal",
     
     "step1":"Étape 1",
     "step2":"Étape 2",

--- a/www/js/gccollab.js
+++ b/www/js/gccollab.js
@@ -947,7 +947,7 @@ myApp.onPageInit('sign-in-old', function (page) {
 });
 
 myApp.onPageInit('home', function (page) {
-    $$('#home-navbar-inner').html(GCTLang.txtGlobalNav('gccollab'));
+    $$('#home-navbar-inner').html(GCTLang.txtGlobalNav('home'));
     var limit = 12;
     var offset_blogs = 0;
     var loaded_blog = false;
@@ -1029,6 +1029,8 @@ myApp.onPageInit('home', function (page) {
 
 
     GCTUser.GetNewsfeed(limit, home.newsfeed.offset, homeNewsfeed, errorConsole);
+    var focusTitle = document.getElementById('home');
+    if (focusTitle) { focusTitle.focus(); }
     $$('#more-' + home.newsfeed.id).on('click', function (e) {
         $('#focus-' + home.newsfeed.id).remove();
         GCTUser.GetNewsfeed(limit, home.newsfeed.offset, homeNewsfeed, errorConsole);

--- a/www/js/gccollab.js
+++ b/www/js/gccollab.js
@@ -70,6 +70,10 @@ $$('.panel-right').on('panel:opened', function () {
     var focusTitle = document.getElementById('message-panel');
     if (focusTitle) { focusTitle.focus(); }
 });
+$$('.panel-left').on('panel:opened', function () {
+    var focusTitle = document.getElementById('menu-panel');
+    if (focusTitle) { focusTitle.focus(); }
+});
 
 function isValidEmailAddress(emailAddress) {
     var pattern = /^([a-z\d!#$%&'*+\-\/=?^_`{|}~\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]+(\.[a-z\d!#$%&'*+\-\/=?^_`{|}~\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]+)*|"((([ \t]*\r\n)?[ \t]+)?([\x01-\x08\x0b\x0c\x0e-\x1f\x7f\x21\x23-\x5b\x5d-\x7e\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]|\\[\x01-\x09\x0b\x0c\x0d-\x7f\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]))*(([ \t]*\r\n)?[ \t]+)?")@(([a-z\d\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]|[a-z\d\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF][a-z\d\-._~\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]*[a-z\d\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])\.)+([a-z\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]|[a-z\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF][a-z\d\-._~\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]*[a-z\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])\.?$/i;

--- a/www/js/gccollab.js
+++ b/www/js/gccollab.js
@@ -66,6 +66,11 @@ $$('.panel-right').on('open', function () {
     LoadMessageCentre();
 });
 
+$$('.panel-right').on('panel:opened', function () {
+    var focusTitle = document.getElementById('message-panel');
+    if (focusTitle) { focusTitle.focus(); }
+});
+
 function isValidEmailAddress(emailAddress) {
     var pattern = /^([a-z\d!#$%&'*+\-\/=?^_`{|}~\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]+(\.[a-z\d!#$%&'*+\-\/=?^_`{|}~\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]+)*|"((([ \t]*\r\n)?[ \t]+)?([\x01-\x08\x0b\x0c\x0e-\x1f\x7f\x21\x23-\x5b\x5d-\x7e\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]|\\[\x01-\x09\x0b\x0c\x0d-\x7f\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]))*(([ \t]*\r\n)?[ \t]+)?")@(([a-z\d\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]|[a-z\d\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF][a-z\d\-._~\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]*[a-z\d\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])\.)+([a-z\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]|[a-z\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF][a-z\d\-._~\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]*[a-z\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])\.?$/i;
     return pattern.test(emailAddress);

--- a/www/js/gccollab.js
+++ b/www/js/gccollab.js
@@ -1038,7 +1038,7 @@ myApp.onPageInit('home', function (page) {
 
 
     GCTUser.GetNewsfeed(limit, home.newsfeed.offset, homeNewsfeed, errorConsole);
-    var focusTitle = document.getElementById('home');
+    var focusTitle = document.getElementById('page-GCcollab');
     if (focusTitle) { focusTitle.focus(); }
     $$('#more-' + home.newsfeed.id).on('click', function (e) {
         $('#focus-' + home.newsfeed.id).remove();

--- a/www/js/gccollab.js
+++ b/www/js/gccollab.js
@@ -958,8 +958,6 @@ myApp.onPageInit('sign-in-old', function (page) {
 myApp.onPageInit('home', function (page) {
     $$('#home-navbar-inner').html(GCTLang.txtGlobalNav('home'));
     var limit = 12;
-    var offset_blogs = 0;
-    var loaded_blog = false;
 
     var home = {}; //variables for this page's content
     home.newsfeed = listObject("home-newsfeed");
@@ -1038,8 +1036,12 @@ myApp.onPageInit('home', function (page) {
 
 
     GCTUser.GetNewsfeed(limit, home.newsfeed.offset, homeNewsfeed, errorConsole);
-    var focusTitle = document.getElementById('page-GCcollab');
+    var focusTitle = document.getElementById('page-home');
     if (focusTitle) { focusTitle.focus(); }
+    $$('#tab-' + home.newsfeed.id).on('show', function (e) {
+        var focusTitle = document.getElementById('tabheader-home-newsfeed');
+        if (focusTitle) { focusTitle.focus(); }
+    });
     $$('#more-' + home.newsfeed.id).on('click', function (e) {
         $('#focus-' + home.newsfeed.id).remove();
         GCTUser.GetNewsfeed(limit, home.newsfeed.offset, homeNewsfeed, errorConsole);
@@ -1047,9 +1049,10 @@ myApp.onPageInit('home', function (page) {
 
     $$('#tab-' + home.wire.id).on('show', function (e) {
         if (!home.wire.loaded) {
-            home.wire.loaded = true;
             GCTUser.GetWires(limit, home.wire.offset, '', homeWires, errorConsole);
         }
+        var focusTitle = document.getElementById('tabheader-home-wires');
+        if (focusTitle) { focusTitle.focus(); }
     });
     $$('#more-' + home.wire.id).on('click', function (e) {
         $('#focus-' + home.wire.id).remove();
@@ -1057,10 +1060,11 @@ myApp.onPageInit('home', function (page) {
     });
 
     $$('#tab-' + home.blogs.id).on('show', function (e) {
-        if (!loaded_blog) {
-            loaded_blog = true;
+        if (!home.blogs.loaded) {
             GCTUser.GetBlogs(limit, home.blogs.offset, "", homeBlogs, errorConsole);
         }
+        var focusTitle = document.getElementById('tabheader-home-blogs');
+        if (focusTitle) { focusTitle.focus(); }
     });
     $$('#more-' + home.blogs.id).on('click', function (e) {
         $('#focus-' + home.blogs.id).remove();


### PR DESCRIPTION
Side Panels focus to the content inside it. Message Panel to the existing title. Main Menu to an invisible screen reader only title. closes #210 

txtGlobalNav has extra html. Adds screen reader only text stating page and title. Sets focus to the start of the page. Deals with previous pages being in the html for #191 Only being utilized by home page. Will be added to other pages.

For tabs on home, setup that on show will focus the title. #211 - will utilize on other content list pages, but with screen reader only title. 

On Home - Added Navigation and Labels for the different bars. Navigation, Tab/Sub, And Bottom Toolbar. Useful for screen reader navigation. ToDo utilize on other pages. 