### PR TITLE
List-Template Tab-Header + home tab headers

### DIFF
--- a/www/js/GCT.js
+++ b/www/js/GCT.js
@@ -36,6 +36,23 @@
         }
         return filter;
     },
+    txtTabHeader: function (ref) {
+        var header = '';
+        switch (ref) {
+            case 'newsfeed':
+                header = '<div class="block small"><div class="row"><div class="col-66"><h2 class="no-margin" data-translate="newsfeed" tabindex="0" id="tabheader-home-newsfeed">' + GCTLang.Trans("newsfeed") +'</h2></div></div></div>';
+                break;
+            case 'the-wire':
+                header = '<div class="block small"><div class="row"><div class="col-66"><h2 class="no-margin" data-translate="the-wire" tabindex="0" id="tabheader-home-wire">' + GCTLang.Trans("the-wire") + '</h2></div>'
+                    + '<div class="col-33"><a href="/list-template/wires/" class="button button-fill pull-right" >' + GCTLang.Trans("view-all") +'</a></div></div></div>';
+                break;
+            case 'blogs':
+                header = '<div class="block small"><div class="row"><div class="col-66"><h2 class="no-margin" data-translate="blogs" tabindex="0" id="tabheader-home-wire">' + GCTLang.Trans("blogs") + '</h2></div>'
+                    + '<div class="col-33"><a href="/list-template/blogs/" class="button button-fill pull-right" >' + GCTLang.Trans("view-all") + '</a></div></div></div>';
+            default: ;
+        }
+        return header;
+    },
 
     txtNewsfeed: function (object) {
         var content = "<div aria-label='"+object.label+"' tabindex='0'><div class='card' aria-hidden='true' >"
@@ -1310,7 +1327,7 @@ function listObject(id, limit, eachFunc) {
     console.log(object);
     return object;
 }
-function tabObject(page, tab, limit, type, eachFunc, request) {
+function tabObject(page, tab, limit, type, header, eachFunc, request) {
     var object = {
         offset: 0,
         limit: limit,
@@ -1319,6 +1336,7 @@ function tabObject(page, tab, limit, type, eachFunc, request) {
         type: type,
         name: tab,
         page: page,
+        header: GCTtxt.txtTabHeader(header),
         appendMessage: GCTtxt.txtFocusMessage(page + '-' + tab),
         eachFunc: eachFunc,
         request: request,

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -11,9 +11,9 @@ var app  = new Framework7({
         return {
             home: {
                 limit: 12,
-                tabs: [{ id: "newsfeed", each: GCTEach.Newsfeed, request: GCTrequests.GetNewsfeed, type: 'card' },
-                    { id: "the-wire", each: GCTEach.Wire, request: GCTrequests.GetWires, type: 'card' },
-                    { id: "blogs", each: GCTEach.Blog, request: GCTrequests.GetBlogs, type: 'card' }],
+                tabs: [{ id: "newsfeed", each: GCTEach.Newsfeed, request: GCTrequests.GetNewsfeed, type: 'card', header: 'newsfeed' },
+                    { id: "the-wire", each: GCTEach.Wire, request: GCTrequests.GetWires, type: 'card', header: 'the-wire' },
+                    { id: "blogs", each: GCTEach.Blog, request: GCTrequests.GetBlogs, type: 'card', header: 'blogs' }],
                 action: 'post-home',
                 filters: '',
             },

--- a/www/js/routes.js
+++ b/www/js/routes.js
@@ -24,7 +24,7 @@ routes = [
             var action = GCTtxt.txtAction(pageInfo.action);
             var filterButton = GCTtxt.txtFilterButton(pageInfo.filters);
             var tabs = [];
-            pageInfo.tabs.forEach(function (tab) { tabs.push(tabObject(page, tab.id, pageInfo.limit, tab.type, tab.each, tab.request)); });
+            pageInfo.tabs.forEach(function (tab) { tabs.push(tabObject(page, tab.id, pageInfo.limit, tab.type, tab.header, tab.each, tab.request)); });
             
             resolve(
                 {

--- a/www/pages/list-template.html
+++ b/www/pages/list-template.html
@@ -29,6 +29,7 @@
         <div class="tabs">
             {{#each tabs}}
             <div id="tab-{{this.id}}" class="page-content tab {{#if @first}}tab-active{{/if}}">
+                {{this.header}}
                 {{#js_if "this.type == 'card'"}}<div id="content-{{this.id}}" class='list cards-list'></div>{{/js_if}}
                 {{#js_if "this.type == 'item'"}}<div class="list media-list"><ul id="content-{{this.id}}"></ul></div>{{/js_if}}
                 <a id="more-{{this.id}}" class="button button-big button-fill" data-translate="view-more">VIEW MORE</a>


### PR DESCRIPTION
App Data has added header variable inserted for tabs with precontent information. Currently added for homepage tab title + view more buttons, same as the old app uses.

Routes handles sending the reference to the tabObject.

tabObject gets the html from txtTabHeader by passing the reference.

List-Template places the tab header.

#240