### PR TITLE
[F7v2 Migration] Entity template&migration

### DIFF
--- a/www/js/GCT.js
+++ b/www/js/GCT.js
@@ -2401,6 +2401,9 @@ GCT = {
         }
 
         switch (type) {
+            case "gccollab_profile":
+                mainView.router.navigate('/profile-template/user/' + guid + '/');
+                break;
             case "gccollab_group":
                 mainView.router.navigate('/profile-template/group/' + guid + '/');
                 break;

--- a/www/js/GCT.js
+++ b/www/js/GCT.js
@@ -171,7 +171,7 @@
             + "<div class='col-85'></div>"
             + "<a href='#' class='col-15 link pull-right more-options' data-owner='" + object.owner + "' data-guid='" + object.guid + "' data-type='" + object.type + "' onclick='GCTUser.MoreOptions(this);'  aria-label='More Options'><i class='fas fa-ellipsis-h fa-2x'></i></a>"
             + "</div>"
-            + "<div class='card-content  card-content-padding item-link' data-guid='" + object.guid + "' data-type='" + object.type + "' onclick='GCT.ViewPost(this);'>"
+            + "<div class='card-content  card-content-padding'>"
             + "<div id='wire-" + object.guid + "'>" + object.description + "</div>"
             + "<div class='item-media'>" + object.image + "</div>"
             + object.source
@@ -210,6 +210,38 @@
             + "</div>"
             + "</div>"
             + "<div class='card-footer' aria-hidden='true'>"
+            + "<a href='#' class='link like " + object.liked + "' data-guid='" + object.guid + "' data-type='" + object.type + "' onclick='GCTUser.LikePost(this);'><i class='far fa-thumbs-up'></i> <span class='like-count'>" + object.likes + "</span></a>"
+            // + "<a href='#' class='link " + object.replied + "' data-guid='" + object.guid + "' data-type='" + object.type + "' onclick='GCTUser.ReplyToPost(this);'><i class='fa fa-reply'></i> <span>" + GCTLang.Trans("reply") + "</span></a>"
+            + object.action
+            + "</div>"
+            + "</div>";
+        content = GCT.SetLinks(content);
+        return content;
+    },
+    Blog: function (object) {
+        var content = "<div class='hold-all-card'>"
+            + "<div class='card'>"
+            + "<div class='card-header' onclick='ShowProfile(" + object.owner + ");'>"
+            + "<div class='item-media rounded'><img alt='Profile Image of " + object.name + "' src='" + object.icon + "' /></div>"
+            + "<div class='item-inner'>"
+            + "<div class='item-title-row'>"
+            + "<div class='author'>" + object.name + "</div>"
+            + "</div>"
+            + "<div class='time'>" + object.date + "</div>"
+            + "</div>"
+            + "</div>"
+            + "<div class='row'>"
+            + "<div class='col-85'></div>"
+            + "<a href='#' class='col-15 link pull-right more-options' data-owner='" + object.owner + "' data-guid='" + object.guid + "' data-type='" + object.type + "' onclick='GCTUser.MoreOptions(this);'  aria-label='More Options'><i class='fas fa-ellipsis-h fa-2x'></i></a>"
+            + "</div>"
+            + "<div class='card-content card-content-padding'>"
+            + "<div id='blog-" + object.guid + "' class='card-content-inner'>"
+            + "<div class='blog-title'>" + object.title + "</div>"
+            + "<div class='blog-group'>" + object.group + "</div>"
+            + "<div class='item-text large " + object.all_text + "'>" + object.description + "</div>"
+            + "</div>"
+            + "</div>"
+            + "<div class='card-footer'>"
             + "<a href='#' class='link like " + object.liked + "' data-guid='" + object.guid + "' data-type='" + object.type + "' onclick='GCTUser.LikePost(this);'><i class='far fa-thumbs-up'></i> <span class='like-count'>" + object.likes + "</span></a>"
             // + "<a href='#' class='link " + object.replied + "' data-guid='" + object.guid + "' data-type='" + object.type + "' onclick='GCTUser.ReplyToPost(this);'><i class='fa fa-reply'></i> <span>" + GCTLang.Trans("reply") + "</span></a>"
             + object.action
@@ -305,24 +337,52 @@
             + "<div class='blog-title'>" + object.title + "</div>"
             + "<div class='item-text large'>" + object.startDate + "<br>" + object.endDate + "</div>"
             + "<div class='item-text large'>" + object.location + "</div>"
-            + "<div class='item-text large " + object.all_text + "'>" + "<br>" + object.description + "</div>";
-
-        if (object.fullview) { //implement parts for full events popup, rather than the events list
-            content += "<div class='item-text large'>" + "" + "</div>" //placeholder for text after desc
+            + "<div class='item-text large " + object.all_text + "'>" + "<br>" + object.description + "</div>"
+            + "</div>"
+            + "</div>"
+            + "<div class='card-footer' aria-hidden='true'>"
+            + "<a href='#' aria-label='like aimer' class='link like " + object.liked + "' data-guid='" + object.guid + "' data-type='" + object.type + "' onclick='GCTUser.LikePost(this);'><i class='far fa-thumbs-up'></i> <span class='like-count'>" + object.likes + "</span></a>"
+            + object.action
+            + "</div></div></div>";
+        content = GCT.SetLinks(content);
+        return content;
+    },
+    Event: function (object) {
+        var content = "<div class='hold-all-card'>"
+            + "<div id='" + object.id + "' class='card'>"
+            + "<div class='card-header' onclick='ShowProfile(" + object.owner + ");'>"
+            + "<div class='item-media rounded'><img alt='Profile Image of " + object.name + "' src='" + object.icon + "' /></div>"
+            + "<div class='item-inner'>"
+            + "<div class='item-title-row'>"
+            + "<div class='author'>" + object.name + "</div>"
+            + "</div>"
+            + "<div class='time'>" + object.date + "</div>"
+            + "</div>"
+            + "</div>"
+            + "<div class='row'>"
+            + "<div class='col-85'></div>"
+            + "<a href='#' class='col-15 link pull-right more-options' data-owner='" + object.owner + "' data-guid='" + object.guid + "' data-type='" + object.type + "' onclick='GCTUser.MoreOptions(this);'  aria-label='More Options'><i class='fas fa-ellipsis-h fa-2x'></i></a>"
+            + "</div>"
+            + "<div class='card-content card-content-padding'>"
+            + "<div class='card-content-inner'>"
+            + "<div class='blog-title'>" + object.title + "</div>"
+            + "<div class='item-text large'>" + object.startDate + "<br>" + object.endDate + "</div>"
+            + "<div class='item-text large'>" + object.location + "</div>"
+            + "<div class='item-text large " + object.all_text + "'>" + "<br>" + object.description + "</div>"
+            + "<div class='item-text large'>" + "" + "</div>" 
                 + "</div>"
                 + "</div>"
-                + "<div class='card-content'>" + "<hr>"
+            + "<div class='card-content card-content-padding'>" + "<hr>"
                 + "<div class='card-content-inner'>"
                 + "<div class='blog-title'>" + object.additionalTitle + "</div>"
                 + "<div class='item-text large'>" + object.org + "</div>"
                 + "<div class='item-text large'>" + object.phone + "</div>"
                 + "<div class='item-text large'>" + object.email + "</div>"
                 + "<div class='item-text large'>" + object.fee + "</div>"
-                + "<div class='item-text large'>" + object.eventLang + "</div>";
-        }
-        content += "</div>"
+                + "<div class='item-text large'>" + object.eventLang + "</div>"
+                + "</div>"
             + "</div>"
-            + "<div class='card-footer' aria-hidden='true'>"
+            + "<div class='card-footer'>"
             + "<a href='#' aria-label='like aimer' class='link like " + object.liked + "' data-guid='" + object.guid + "' data-type='" + object.type + "' onclick='GCTUser.LikePost(this);'><i class='far fa-thumbs-up'></i> <span class='like-count'>" + object.likes + "</span></a>"
             + object.action
             + "</div></div></div>";

--- a/www/js/GCT.js
+++ b/www/js/GCT.js
@@ -1531,6 +1531,23 @@ GCTrequests = {
             }
         });
     },
+    GetWire: function (guid, thread, successCallback) {
+        thread = thread || 0;
+
+        app.request({
+            method: 'POST',
+            dataType: 'json',
+            url: GCT.GCcollabURL,
+            data: { method: "get.wirepost", user: GCTUser.Email(), guid: guid, thread: thread, api_key: api_key_gccollab, lang: GCTLang.Lang() },
+            timeout: 12000,
+            success: function (data) {
+                successCallback(data);
+            },
+            error: function (jqXHR, textStatus, errorThrown) {
+                errorConsole(jqXHR, textStatus, errorThrown);
+            }
+        });
+    },
     GetWires: function (tabObject) {
         limit = tabObject.limit || 12;
         offset = tabObject.offset || 0;
@@ -2062,7 +2079,9 @@ GCT = {
             case "group":
                 mainView.router.navigate('/profile-template/group/' + guid + '/');
                 break;
-
+            case "gccollab_wire_post":
+                mainView.router.navigate('/entity-template/wire/' + guid + '/');
+                break;
             default:
                 console.log('Worked, but type not handled yet.');
                 break;

--- a/www/js/GCT.js
+++ b/www/js/GCT.js
@@ -1458,6 +1458,21 @@ GCTrequests = {
             }
         });
     },
+    GetBlog: function (guid, successCallback) {
+        app.request({
+            method: 'POST',
+            dataType: 'json',
+            url: GCT.GCcollabURL,
+            data: { method: "get.blogpost", user: GCTUser.Email(), guid: guid, api_key: api_key_gccollab, lang: GCTLang.Lang() },
+            timeout: 12000,
+            success: function (data) {
+                successCallback(data);
+            },
+            error: function (jqXHR, textStatus, errorThrown) {
+                errorConsole(jqXHR, textStatus, errorThrown);
+            }
+        });
+    },
     GetBlogs: function (tabObject) {
         limit = tabObject.limit || 12;
         offset = tabObject.offset || 0;
@@ -2081,6 +2096,9 @@ GCT = {
                 break;
             case "gccollab_wire_post":
                 mainView.router.navigate('/entity-template/wire/' + guid + '/');
+                break;
+            case "gccollab_blog_post":
+                mainView.router.navigate('/entity-template/blog/' + guid + '/');
                 break;
             default:
                 console.log('Worked, but type not handled yet.');

--- a/www/js/GCT.js
+++ b/www/js/GCT.js
@@ -1889,6 +1889,21 @@ GCTrequests = {
             }
         });
     },
+    GetOpportunity: function (guid, successCallback) {
+        app.request({
+            method: 'POST',
+            dataType: 'json',
+            url: GCT.GCcollabURL,
+            data: { method: "get.opportunity", user: GCTUser.Email(), guid: guid, api_key: api_key_gccollab, lang: GCTLang.Lang() },
+            timeout: 12000,
+            success: function (data) {
+                successCallback(data);
+            },
+            error: function (jqXHR, textStatus, errorThrown) {
+                errorCallback(jqXHR, textStatus, errorThrown);
+            }
+        });
+    },
     GetOpportunities: function (tabObject, filters) {
         limit = tabObject.limit || 10;
         offset = tabObject.offset || 0;
@@ -2117,6 +2132,9 @@ GCT = {
                 break;
             case "gccollab_discussion_post":
                 mainView.router.navigate('/entity-template/discussion/' + guid + '/');
+                break;
+            case "gccollab_opportunity":
+                mainView.router.navigate('/entity-template/opportunity/' + guid + '/');
                 break;
             default:
                 console.log('Worked, but type not handled yet.');

--- a/www/js/GCT.js
+++ b/www/js/GCT.js
@@ -471,7 +471,7 @@
             + '</div>'
             + '<div class="time">' + object.date + '<a href="#" class="link pull-right more-options" data-owner="' + object.owner + '" data-guid="' + object.guid + '" data-type="' + object.type + '" onclick="GCTUser.MoreOptions(this);" aria-label="More Options"><i class="fa fa-caret-down"></i></a></div>'
             + object.description
-            + "<div  class='link like " + object.liked + "'><a href='#' aria-label='like aimer' data-guid='" + object.guid + "' data-type='" + object.type + "' onclick='GCTUser.LikePost(this);'><i class='fa fa-thumbs-o-up'></i></a> <a href='#' aria-label='See who liked this Voir qui a aimer' data-guid=" + object.guid + " onclick='GCTUser.GetLikeUsers(this);'><span class='like-count'>" + object.likes + "</span></a></div>"
+            + "<br><div  class='link like " + object.liked + "'><a href='#' aria-label='like aimer' data-guid='" + object.guid + "' data-type='" + object.type + "' onclick='GCTUser.LikePost(this);'><i class='fa fa-thumbs-o-up'></i></a> <a href='#' aria-label='See who liked this Voir qui a aimer' data-guid=" + object.guid + " onclick='GCTUser.GetLikeUsers(this);'><span class='like-count'>" + object.likes + "</span></a></div>"
 
             + '</div>'
             + '</div>'
@@ -2056,6 +2056,21 @@ GCTrequests = {
             },
             error: function (jqXHR, textStatus, errorThrown) {
                 errorConsole(jqXHR, textStatus, errorThrown);
+            }
+        });
+    },
+    SubmitComment: function (guid, message, successCallback, errorCallback) {
+        app.request({
+            method: 'POST',
+            dataType: 'json',
+            url: GCT.GCcollabURL,
+            data: { method: "submit.comment", user: GCTUser.Email(), guid: guid, message: message, api_key: api_key_gccollab, lang: GCTLang.Lang() },
+            timeout: 12000,
+            success: function (data) {
+                successCallback(data);
+            },
+            error: function (jqXHR, textStatus, errorThrown) {
+                errorCallback(jqXHR, textStatus, errorThrown);
             }
         });
     },

--- a/www/js/GCT.js
+++ b/www/js/GCT.js
@@ -1743,6 +1743,21 @@ GCTrequests = {
             }
         });
     },
+    GetDiscussion: function (guid, successCallback) {
+        app.request({
+            method: 'POST',
+            dataType: 'json',
+            url: GCT.GCcollabURL,
+            data: { method: "get.discussion", user: GCTUser.Email(), guid: guid, api_key: api_key_gccollab, lang: GCTLang.Lang() },
+            timeout: 12000,
+            success: function (data) {
+                successCallback(data);
+            },
+            error: function (jqXHR, textStatus, errorThrown) {
+                errorConsole(jqXHR, textStatus, errorThrown);
+            }
+        });
+    },
     GetMembers: function (tabObject, filters) {
         limit = tabObject.limit || 15;
         offset = tabObject.offset || 0;
@@ -2099,6 +2114,9 @@ GCT = {
                 break;
             case "gccollab_blog_post":
                 mainView.router.navigate('/entity-template/blog/' + guid + '/');
+                break;
+            case "gccollab_discussion_post":
+                mainView.router.navigate('/entity-template/discussion/' + guid + '/');
                 break;
             default:
                 console.log('Worked, but type not handled yet.');

--- a/www/js/GCT.js
+++ b/www/js/GCT.js
@@ -461,6 +461,24 @@
             + '</div></li>';
         return content;
     },
+    txtComment: function (object) {
+        var content = '<li>'
+            + '<div class="item-link item-content">'
+            + '<div class="item-media"> <img src="' + object.icon + '" onclick="ShowProfile(' + object.owner + ');" style="border-radius:100%" width="40" height="40" alt="Profile Picture"> </div>'
+            + '<div class="item-inner">'
+            + '<div class="item-title-row">'
+            + '<div class="item-title author-comment">' + object.name + '</div>'
+            + '</div>'
+            + '<div class="time">' + object.date + '<a href="#" class="link pull-right more-options" data-owner="' + object.owner + '" data-guid="' + object.guid + '" data-type="' + object.type + '" onclick="GCTUser.MoreOptions(this);" aria-label="More Options"><i class="fa fa-caret-down"></i></a></div>'
+            + object.description
+            + "<div  class='link like " + object.liked + "'><a href='#' aria-label='like aimer' data-guid='" + object.guid + "' data-type='" + object.type + "' onclick='GCTUser.LikePost(this);'><i class='fa fa-thumbs-o-up'></i></a> <a href='#' aria-label='See who liked this Voir qui a aimer' data-guid=" + object.guid + " onclick='GCTUser.GetLikeUsers(this);'><span class='like-count'>" + object.likes + "</span></a></div>"
+
+            + '</div>'
+            + '</div>'
+            + '</li>';
+        content = GCT.SetLinks(content);
+        return content;
+    },
 }
 
 GCTEach = {
@@ -1117,6 +1135,24 @@ GCTEach = {
             title: value.title,
             sender: value.fromUserDetails.displayName,
             guid: value.guid
+        });
+        return content;
+    },
+    Comment: function (value) {
+        console.log(value);
+        var liked = (value.liked) ? "liked" : "";
+        var likes = (value.likes > 0) ? value.likes + (value.likes == 1 ? GCTLang.Trans("like") : GCTLang.Trans("likes")) : GCTLang.Trans("like");
+
+        var content = GCTtxt.txtComment({
+            icon: value.userDetails.iconURL,
+            name: value.userDetails.displayName,
+            owner: value.owner_guid,
+            date: prettyDate(value.time_created),
+            description: value.description,
+            type: value.subtype,
+            guid: value.guid,
+            liked: liked,
+            likes: likes
         });
         return content;
     },
@@ -2000,6 +2036,23 @@ GCTrequests = {
             timeout: 12000,
             success: function (data) {
                 GCTEach.ContentSuccess(data, tabObject);
+            },
+            error: function (jqXHR, textStatus, errorThrown) {
+                errorConsole(jqXHR, textStatus, errorThrown);
+            }
+        });
+    },
+    GetComments: function (guid, limit, offset, successCallback) {
+        limit = limit || 10;
+        offset = offset || 0;
+        app.request({
+            method: 'POST',
+            dataType: 'json',
+            url: GCT.GCcollabURL,
+            data: { method: "get.commentsall", user: GCTUser.Email(), guid: guid, limit: limit, offset: offset, api_key: api_key_gccollab, lang: GCTLang.Lang() },
+            timeout: 12000,
+            success: function (data) {
+                successCallback(data);
             },
             error: function (jqXHR, textStatus, errorThrown) {
                 errorConsole(jqXHR, textStatus, errorThrown);

--- a/www/js/GCT.js
+++ b/www/js/GCT.js
@@ -142,7 +142,7 @@
             + "<a href='#' class='col-15 link pull-right more-options' data-owner='" + object.owner + "' data-guid='" + object.guid + "' data-type='" + object.type + "' onclick='GCTUser.MoreOptions(this);'  aria-label='More Options'><i class='fas fa-ellipsis-h fa-2x'></i></a>"
             + "</div>"
             + "<div class='card-content  card-content-padding item-link' data-guid='" + object.guid + "' data-type='" + object.type + "' onclick='GCT.ViewPost(this);' aria-hidden='true'>"
-            + "<div id='wire-" + object.guid + "' class='item-text large'>" + object.description + "</div>"
+            + "<div id='wire-" + object.guid + "'>" + object.description + "</div>"
             + "<div class='item-media'>" + object.image + "</div>"
             + object.source
             + "</div>"
@@ -1155,7 +1155,7 @@ GCTEach = {
         obj.offset += obj.limit;
         var focusNow = document.getElementById('focus-' + obj.id);
         if (focusNow) { focusNow.focus(); }
-    }
+    },
 }
 
 GCTtabs = {

--- a/www/js/GCT.js
+++ b/www/js/GCT.js
@@ -421,8 +421,38 @@
         content = GCT.SetLinks(content);
         return content;
     },
+    Bookmark: function (object) {
+        var content = "<div class='hold-all-card'>"
+            + "<div class='card'>"
+            + "<div class='card-header' onclick='ShowProfile(" + object.owner + ");'>"
+            + "<div class='item-media rounded'><img alt='Profile Image of " + object.name + "' src='" + object.icon + "' /></div>"
+            + "<div class='item-inner'>"
+            + "<div class='item-title-row'>"
+            + "<div class='author'>" + object.name + "</div>"
+            + "</div>"
+            + "<div class='time'>" + object.date + "</div>"
+            + "</div>"
+            + "</div>"
+            + "<div class='row'>"
+            + "<div class='col-85'></div>"
+            + "<a href='#' class='col-15 link pull-right more-options' data-owner='" + object.owner + "' data-guid='" + object.guid + "' data-type='" + object.type + "' onclick='GCTUser.MoreOptions(this);'  aria-label='More Options'><i class='fas fa-ellipsis-h fa-2x'></i></a>"
+            + "</div>"
+            + "<div class='card-content  card-content-padding'>"
+            + "<div class='card-content-inner'>"
+            + "<div class='blog-title'>" + object.title + "</div>"
+            + "<div class='blog-group'>" + object.posted + "</div>"
+            + "<div class='item-text large'>" + object.description + "</div>"
+            + "<div class='blog-group'>" + "Link: " + object.address + "</div>"
+            + "</div>"
+            + "</div>"
+            + "<div class='card-footer'>"
+            + "<div  class='link like " + object.liked + "'><a href='#' aria-label='like aimer' data-guid='" + object.guid + "' data-type='" + object.type + "' onclick='GCTUser.LikePost(this);'><i class='far fa-thumbs-up'></i></a> <a href='#' aria-label='See who liked this Voir qui a aimer' data-guid=" + object.guid + " onclick='GCTUser.GetLikeUsers(this);'><span class='like-count'>" + object.likes + "</span></a></div>"
+            + object.action
+            + "</div></div></div>";
+        content = GCT.SetLinks(content);
+        return content;
+    },
     txtOpps: function (object) {
-
         if (object.state == 'posted') {
             var content = "<div class='hold-all-card'>"
                 + "<div id='label-" + object.guid + "' class='reader-text' data-guid='" + object.guid + "' data-type='" + object.type + "' onclick='GCT.ViewPost(this);'>" + object.label + "</div>"
@@ -444,13 +474,52 @@
                 + "<div class='card-content-inner'" + object.all_text + ">"
                 + "<div class='blog-title'>" + object.title + "</div>"
                 + "<div class='title'> <b>" + object.jobtype + "(" + object.roletype + ")" + "</b></div>"
-                + "<div class='item-text large " + object.all_text + "'>" + object.description + "</div>";
+                + "<div class='item-text large " + object.all_text + "'>" + object.description + "</div>"
+                + "<div class='item-text large'>" + object.deadline + "</div>"
+                + "<div class='item-text'>" + object.programArea + "</div>"
+                + "</div>"
+                + "</div>"
+                + "<div class='card-footer' aria-hidden='true'>"
+                + object.action;
+            if (object.apply == 'mission_apply') { content += "<a href='#' class='link' data-guid='" + object.guid + "' data-type='" + object.type + "' onclick='GCTUser.ApplyPost(this);'> <span>" + GCTLang.Trans('apply-opt') + "</span></a>"; }
+            else if (object.apply == 'withdraw') { content += "<a href='#' class='link' data-guid='" + object.guid + "' data-type='" + object.type + "' onclick='GCTUser.WithdrawPost(this);'> <span>" + GCTLang.Trans('withdrawn-opt') + "</span></a>"; }
+            else if (object.apply == 'offered') { content += "<a href='#' class='link' data-guid='" + object.guid + "' data-type='" + object.type + "' onclick='GCTUser.AcceptPost(this);'> <span>" + GCTLang.Trans('accept-opt') + "</span></a><a href='#' class='link' data-guid='" + object.guid + "' data-type='" + object.type + "' onclick='GCTUser.WithdrawPost(this);'> <span>" + GCTLang.Trans('decline-opt') + "</span></a>"; }
 
-            if (object.fullview) { //implement parts for full events popup, rather than the events list
-                content += "<div class='item-text large'>" + "" + "</div>" //placeholder for text after desc
+            content += "</div>"
+                + "</div></div>";
+        } else {
+            var content = "<div class='swiper-slide list-block cards-list'>";// need something hidden 
+        }
+        content = GCT.SetLinks(content);
+        return content;
+
+    },
+    Opps: function (object) {
+        if (object.state == 'posted') {
+            var content = "<div class='hold-all-card'>"
+                + "<div class='card view view-main'>"
+                + "<div class='card-header' onclick='ShowProfile(" + object.owner + ");' aria-hidden='true'>"
+                + "<div class='item-media rounded'><img alt='Profile Image of " + object.name + "' src='" + object.icon + "' /></div>"
+                + "<div class='item-inner'>"
+                + "<div class='item-title-row'>"
+                + "<div class='author'>" + object.name + "</div>"
+                + "</div>"
+                + "<div class='time'>" + object.date + "</div>"
+                + "</div>"
+                + "</div>"
+                + "<div class='row'>"
+                + "<div class='col-85'></div>"
+                + "<a href='#' class='col-15 link pull-right more-options' data-owner='" + object.owner + "' data-guid='" + object.guid + "' data-type='" + object.type + "' onclick='GCTUser.MoreOptions(this);' aria-label='More Options'><i class='fas fa-ellipsis-h fa-2x'></i></a>"
+                + "</div>"
+                + "<div class='card-content card-content-padding'>"
+                + "<div class='card-content-inner'" + object.all_text + ">"
+                + "<div class='blog-title'>" + object.title + "</div>"
+                + "<div class='title'> <b>" + object.jobtype + "(" + object.roletype + ")" + "</b></div>"
+                + "<div class='item-text large " + object.all_text + "'>" + object.description + "</div>"
+                     + "<div class='item-text large'>" + "" + "</div>" //placeholder for text after desc
                     + "</div>"
                     + "</div>"
-                    + "<div class='card-content'>" + "<hr>"
+                + "<div class='card-content card-content-padding'>" + "<hr>"
                     + "<div class='card-content-inner'>"
                     + "<div class='blog-title'>" + object.additionalTitle + "</div>" //change from 'blog' title later
                     + "<div class='item-text'>" + object.programArea + "</div>"
@@ -472,14 +541,10 @@
                     + "<div class='item-text large'>" + object.schedulingReq + "</div>"
                     + "<br>"
                     + "<div class='item-text large'>" + object.participants + "</div>"
-                    + "<div class='item-text large'>" + object.applicants + "</div>";
-            } else {
-                content += "<div class='item-text large'>" + object.deadline + "</div>"
-                    + "<div class='item-text'>" + object.programArea + "</div>";
-            }
-            content += "</div>"
+                    + "<div class='item-text large'>" + object.applicants + "</div>"
                 + "</div>"
-                + "<div class='card-footer' aria-hidden='true'>"
+                + "</div>"
+                + "<div class='card-footer'>"
             content += object.action
             if (object.apply == 'mission_apply') { content += "<a href='#' class='link' data-guid='" + object.guid + "' data-type='" + object.type + "' onclick='GCTUser.ApplyPost(this);'> <span>" + GCTLang.Trans('apply-opt') + "</span></a>"; }
             else if (object.apply == 'withdraw') { content += "<a href='#' class='link' data-guid='" + object.guid + "' data-type='" + object.type + "' onclick='GCTUser.WithdrawPost(this);'> <span>" + GCTLang.Trans('withdrawn-opt') + "</span></a>"; }
@@ -518,6 +583,36 @@
             + "<div class='item-text large " + object.all_text + "'>" + object.description + "</div>"
             + "</div>"
             + "<div class='card-footer' aria-hidden='true'>"
+            + "<div  class='link like " + object.liked + "'><a href='#' aria-label='like aimer' data-guid='" + object.guid + "' data-type='" + object.type + "' onclick='GCTUser.LikePost(this);'><i class='far fa-thumbs-up'></i></a> <a href='#' aria-label='See who liked this Voir qui a aimer' data-guid=" + object.guid + " onclick='GCTUser.GetLikeUsers(this);'><span class='like-count'>" + object.likes + "</span></a></div>"
+            // + "<a href='#' class='link " + object.replied + "' data-guid='" + object.guid + "' data-type='" + object.type + "' onclick='GCTUser.ReplyToPost(this);'><i class='fa fa-reply'></i> <span>" + GCTLang.Trans("reply") + "</span></a>"
+            + object.action
+            + "</div></div></div></div>";
+        content = GCT.SetLinks(content);
+        return content;
+    },
+    Discussion: function (object) {
+        var content = "<div class='hold-all-card'>"
+            + "<div class='list cards-list'>"
+            + "<div class='card'>"
+            + "<div class='card-header' onclick='ShowProfile(" + object.owner + ");'>"
+            + "<div class='item-media rounded'><img alt='Profile Image of " + object.name + "' src='" + object.icon + "' /></div>"
+            + "<div class='item-inner'>"
+            + "<div class='item-title-row'>"
+            + "<div class='author'>" + object.name + "</div>"
+            + "</div>"
+            + "<div class='time'>" + object.date + "</div>"
+            + "</div>"
+            + "</div>"
+            + "<div class='row'>"
+            + "<div class='col-85'></div>"
+            + "<a href='#' class='col-15 link pull-right more-options' data-owner='" + object.owner + "' data-guid='" + object.guid + "' data-type='" + object.type + "' onclick='GCTUser.MoreOptions(this);'  aria-label='More Options'><i class='fas fa-ellipsis-h fa-2x'></i></a>"
+            + "</div>"
+            + "<div class='card-content card-content-padding'>"
+            + "<div class='blog-title'>" + object.title + "</div>"
+            + "<div class='blog-group'>" + object.group + "</div>"
+            + "<div class='item-text large " + object.all_text + "'>" + object.description + "</div>"
+            + "</div>"
+            + "<div class='card-footer'>"
             + "<div  class='link like " + object.liked + "'><a href='#' aria-label='like aimer' data-guid='" + object.guid + "' data-type='" + object.type + "' onclick='GCTUser.LikePost(this);'><i class='far fa-thumbs-up'></i></a> <a href='#' aria-label='See who liked this Voir qui a aimer' data-guid=" + object.guid + " onclick='GCTUser.GetLikeUsers(this);'><span class='like-count'>" + object.likes + "</span></a></div>"
             // + "<a href='#' class='link " + object.replied + "' data-guid='" + object.guid + "' data-type='" + object.type + "' onclick='GCTUser.ReplyToPost(this);'><i class='fa fa-reply'></i> <span>" + GCTLang.Trans("reply") + "</span></a>"
             + object.action

--- a/www/js/GCT.js
+++ b/www/js/GCT.js
@@ -155,6 +155,36 @@
         content = GCT.SetLinks(content);
         return content;
     },
+    Wire: function (object) {
+        var content = "<div class='hold-all-card'>"
+            + "<div class='card'>"
+            + "<div class='card-header' onclick='ShowProfile(" + object.owner + ");'>"
+            + "<div class='item-media rounded'><img alt='Profile Image of " + object.name + "' src='" + object.icon + "' /></div>"
+            + "<div class='item-inner'>"
+            + "<div class='item-title-row'>"
+            + "<div class='author'>" + object.name + "</div>"
+            + "</div>"
+            + "<div class='time'>" + object.date + "</div>"
+            + "</div>"
+            + "</div>"
+            + "<div class='row'>"
+            + "<div class='col-85'></div>"
+            + "<a href='#' class='col-15 link pull-right more-options' data-owner='" + object.owner + "' data-guid='" + object.guid + "' data-type='" + object.type + "' onclick='GCTUser.MoreOptions(this);'  aria-label='More Options'><i class='fas fa-ellipsis-h fa-2x'></i></a>"
+            + "</div>"
+            + "<div class='card-content  card-content-padding item-link' data-guid='" + object.guid + "' data-type='" + object.type + "' onclick='GCT.ViewPost(this);'>"
+            + "<div id='wire-" + object.guid + "'>" + object.description + "</div>"
+            + "<div class='item-media'>" + object.image + "</div>"
+            + object.source
+            + "</div>"
+            + "<div class='card-footer'>"
+            + "<a href='#' class='link like " + object.liked + "' data-guid='" + object.guid + "' data-type='" + object.type + "' onclick='GCTUser.LikePost(this);'><i class='far fa-thumbs-up'></i> <span class='like-count'>" + object.likes + "</span></a>"
+            + "<a href='#' class='link " + object.replied + "' data-guid='" + object.guid + "' data-type='" + object.type + "' onclick='GCTUser.ReplyWirePost(this);'><i class='fas fa-reply'></i> <span>" + GCTLang.Trans("reply") + "</span></a>"
+            + object.action
+            + "</div>"
+            + "</div><div>";
+        content = GCT.SetLinks(content);
+        return content;
+    },
     txtBlog: function (object) {
         var content = "<div class='hold-all-card'>"
             + "<div id='label-" + object.guid + "' class='reader-text' data-guid='" + object.guid + "' data-type='" + object.type + "' onclick='GCT.ViewPost(this);'>" + object.label + "</div>"

--- a/www/js/GCT.js
+++ b/www/js/GCT.js
@@ -2410,6 +2410,9 @@ GCT = {
             case "group":
                 mainView.router.navigate('/profile-template/group/' + guid + '/');
                 break;
+            case "gccollab_doc":
+                mainView.router.navigate('/doc/' + guid + '/');
+                break;
             case "gccollab_wire_post":
                 mainView.router.navigate('/entity-template/wire/' + guid + '/');
                 break;

--- a/www/js/GCT.js
+++ b/www/js/GCT.js
@@ -1815,6 +1815,21 @@ GCTrequests = {
             }
         });
     },
+    GetEvent: function (guid, successCallback) {
+        app.request({
+            method: 'POST',
+            dataType: 'json',
+            url: GCT.GCcollabURL,
+            data: { method: "get.event", user: GCTUser.Email(), guid: guid, api_key: api_key_gccollab, lang: GCTLang.Lang() },
+            timeout: 12000,
+            success: function (data) {
+                successCallback(data);
+            },
+            error: function (jqXHR, textStatus, errorThrown) {
+                errorConsole(jqXHR, textStatus, errorThrown);
+            }
+        });
+    },
     GetEvents: function (tabObject, from, to) {
         limit = tabObject.limit || 15;
         offset = tabObject.offset || 0;
@@ -2153,6 +2168,9 @@ GCT = {
                 break;
             case "gccollab_bookmark":
                 mainView.router.navigate('/entity-template/bookmark/' + guid + '/');
+                break;
+            case "gccollab_event":
+                mainView.router.navigate('/entity-template/event/' + guid + '/');
                 break;
             default:
                 console.log('Worked, but type not handled yet.');

--- a/www/js/GCT.js
+++ b/www/js/GCT.js
@@ -1835,6 +1835,21 @@ GCTrequests = {
             }
         });
     },
+    GetBookmark: function (guid, successCallback) {
+        app.request({
+            method: 'POST',
+            dataType: 'json',
+            url: GCT.GCcollabURL,
+            data: { method: "get.bookmark", user: GCTUser.Email(), guid: guid, api_key: api_key_gccollab, lang: GCTLang.Lang() },
+            timeout: 12000,
+            success: function (data) {
+                successCallback(data);
+            },
+            error: function (jqXHR, textStatus, errorThrown) {
+                errorConsole(jqXHR, textStatus, errorThrown);
+            }
+        });
+    },
     GetBookmarks: function (tabObject, filters) {
         limit = tabObject.limit || 15;
         offset = tabObject.offset || 0;
@@ -2135,6 +2150,9 @@ GCT = {
                 break;
             case "gccollab_opportunity":
                 mainView.router.navigate('/entity-template/opportunity/' + guid + '/');
+                break;
+            case "gccollab_bookmark":
+                mainView.router.navigate('/entity-template/bookmark/' + guid + '/');
                 break;
             default:
                 console.log('Worked, but type not handled yet.');

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -106,10 +106,12 @@ var app  = new Framework7({
             },
             wire: {
                 comments: false,
-                request: GCTrequests.GetWire,
-                each: GCTEach.Wire,
                 id: 'wire',
             },
+            blog: {
+                comments: true,
+                id: 'blog',
+            }
         };
     },
   // App routes

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -104,6 +104,12 @@ var app  = new Framework7({
                 action: '',
                 filters: '',
             },
+            wire: {
+                comments: false,
+                request: GCTrequests.GetWire,
+                each: GCTEach.Wire,
+                id: 'wire',
+            },
         };
     },
   // App routes

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -119,6 +119,10 @@ var app  = new Framework7({
             opportunity: {
                 comments: false,
                 id: 'opportunity',
+            },
+            bookmark: {
+                comments: true,
+                id: 'bookmark',
             }
             
         };

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -111,6 +111,10 @@ var app  = new Framework7({
             blog: {
                 comments: true,
                 id: 'blog',
+            },
+            discussion: {
+                comments: true,
+                id: 'discussion',
             }
         };
     },

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -123,6 +123,10 @@ var app  = new Framework7({
             bookmark: {
                 comments: true,
                 id: 'bookmark',
+            },
+            event: {
+                comments: true,
+                id: 'event',
             }
             
         };

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -115,7 +115,12 @@ var app  = new Framework7({
             discussion: {
                 comments: true,
                 id: 'discussion',
+            },
+            opportunity: {
+                comments: false,
+                id: 'opportunity',
             }
+            
         };
     },
   // App routes

--- a/www/js/routes.js
+++ b/www/js/routes.js
@@ -99,6 +99,24 @@ routes = [
         }
     },
     {
+        path: '/doc/:guid/',
+        async: function (routeTo, routeFrom, resolve, reject) {
+            var guid = routeTo.params.guid;
+            var navbar = GCTtxt.txtGlobalNav('docs');
+            resolve(
+                {
+                    componentUrl: './pages/doc.html',
+                },
+                {
+                    context: {
+                        navbar: navbar,
+                        guid: guid,
+                    }
+                }
+            )
+        }
+    },
+    {
         path: '/form/',
         url: './pages/form.html',
     },

--- a/www/js/routes.js
+++ b/www/js/routes.js
@@ -76,6 +76,31 @@ routes = [
         }
     },
     {
+        path: '/entity-template/:type/:guid/',
+        async: function (routeTo, routeFrom, resolve, reject) {
+            var type = routeTo.params.type;
+            var guid = routeTo.params.guid;
+            var pageInfo = [];
+            pageInfo = app.data[type];
+            var navbar = GCTtxt.txtGlobalNavGUID(type, guid);
+            resolve(
+                {
+                    componentUrl: './pages/entity-template.html',
+                },
+                {
+                    context: {
+                        navbar: navbar,
+                        comments: pageInfo.comments,
+                        each: pageInfo.each,
+                        request: pageInfo.request,
+                        guid: guid,
+                        type: type,
+                    }
+                }
+            )
+        }
+    },
+    {
         path: '/form/',
         url: './pages/form.html',
     },

--- a/www/js/routes.js
+++ b/www/js/routes.js
@@ -91,8 +91,6 @@ routes = [
                     context: {
                         navbar: navbar,
                         comments: pageInfo.comments,
-                        each: pageInfo.each,
-                        request: pageInfo.request,
                         guid: guid,
                         type: type,
                     }

--- a/www/pages/doc.html
+++ b/www/pages/doc.html
@@ -1,0 +1,39 @@
+<template>
+    <div class="page navbar-fixed">
+        <div class="navbar">
+            <div class="navbar-inner">
+                <div id="doc-{{guid}}-navbar-inner" class="navbar-inner" role="navigation" data-translate-target="aria-label" data-translate="navigation-bar">
+                    {{navbar}}
+                </div>
+            </div>
+        </div>
+        <div class="toolbar toolbar-bottom-md">
+            <div class="toolbar-inner">
+                <div class="left sliding"><a href="#" class="link back" aria-label="Back Button"><i class="far fa-arrow-alt-circle-left fa-2x"></i></a></div>
+            </div>
+        </div>
+        <div class="page-content">
+            <form action="https://gccollab.ca/services/api/rest/json/?" target="doc-iframe" method="post" id="docForm">
+                <input type="hidden" name="method" value="login.userfordocs" />
+                <input type="hidden" id="user" name="user" value="" />
+                <input type="hidden" id="api_key" name="api_key" value="" />
+                <input type="hidden" id="guid" name="guid" value="" />
+                <input type="hidden" name="_persistent" value="true" />
+            </form>
+            <iframe name="doc-iframe" id="doc-iframe" />
+        </div>
+    </div>
+</template>
+<script>
+    return {
+        on: {
+            pageInit: function (e, page) {
+                $("#user").val(GCTUser.Email());
+                $("#api_key").val(api_key_gccollab);
+                $("#guid").val(this.guid);
+                $("#docForm").submit(); 
+            },
+            
+        }
+    }
+</script>

--- a/www/pages/entity-template.html
+++ b/www/pages/entity-template.html
@@ -186,6 +186,125 @@
                             $(content).hide().appendTo('#content-entity-' + guid).fadeIn(500);
                         });
                         break;
+                    case 'opportunity':
+                        $("#comment-card").hide();
+                        GCTrequests.GetOpportunity(guid, function (data) {
+                            var opportunity = data.result;
+                            var content = "";
+                            $(opportunity).each(function (key, value) {
+
+                                var text = (value.description) ? value.description : "";
+
+                                var oppType = (value.jobType) ? oppType += jobType : "";
+
+                                var source = "";
+                                if (value.shareText && value.shareURL)
+                                    source = "<blockquote>Source: <a onclick='GCT.FireLink(this);' href='" + value.shareURL + "'>" + value.shareText + "</a></blockquote>";
+
+                                var jobtype = '';
+                                if (value.jobtype) { jobtype += value.jobtype; }
+
+                                var roletype = '';
+                                if (value.roletype) { roletype += value.roletype; }
+
+                                var programArea = "<b>" + GCTLang.Trans("program-area") + "</b>";
+                                if (value.programArea) { programArea += value.programArea; }
+
+                                var numOpportunities = "<b>" + GCTLang.Trans("num-opportunities") + "</b>";
+                                if (value.numOpportunities) { numOpportunities += value.numOpportunities; }
+
+                                var idealStart = "<b>" + GCTLang.Trans("ideal-start") + "</b>";
+                                if (value.idealStart) { idealStart += value.idealStart; }
+
+                                var idealComplete = "<b>" + GCTLang.Trans("ideal-complete") + "</b>";
+                                if (value.idealComplete) { idealComplete += value.idealComplete; }
+
+                                var deadline = "<b>" + GCTLang.Trans("deadline") + "</b>";
+                                if (value.deadline) { deadline += value.deadline; }
+
+                                var oppVirtual = "<b>" + GCTLang.Trans("opportunity-virtual") + "</b>";
+                                if (value.oppVirtual) { oppVirtual += value.oppVirtual; }
+
+                                var oppOnlyIn = "<b>" + GCTLang.Trans("opportunity-in") + "</b>";
+                                if (value.oppOnlyIn) { oppOnlyIn += value.oppOnlyIn; }
+
+                                var location = "<b>" + GCTLang.Trans("opportunity-location") + "</b>";
+                                if (value.location) { location += value.location; }
+
+                                var security = "<b>" + GCTLang.Trans("opportunity-security") + "</b>";
+                                if (value.security) { security += value.security; }
+
+                                var skills = "<b>" + GCTLang.Trans("opportunity-skills") + "</b>";
+                                if (value.skills) { skills += value.skills; }
+
+                                var languageReq = '';
+                                if (value.languageRequirements) { languageReq = value.languageRequirements; }
+
+                                var schedulingReq = "";
+                                if (value.schedulingRequirements) { schedulingReq += value.schedulingRequirements; }
+
+                                var timezone = "<b>" + GCTLang.Trans("opportunity-timezone") + "</b>";
+                                if (value.timezone) { timezone += value.timezone; }
+                                var timecommitment = "<b>" + GCTLang.Trans("opportunity-time-commitment") + "</b>";
+                                if (value.timecommitment) { timecommitment += value.timecommitment; }
+
+                                var participants = "<b>" + GCTLang.Trans("participants") + "</b>";
+                                if (value.participants) { participants += value.participants; }
+
+                                var applicants = "<b>" + GCTLang.Trans("applicants") + "</b>";
+                                if (value.applicants) { applicants += value.applicants; }
+
+                                var liked = (value.liked) ? "liked" : "";
+                                var likes = (value.likes > 0) ? value.likes + (value.likes == 1 ? GCTLang.Trans("like") : GCTLang.Trans("likes")) : GCTLang.Trans("like");
+                                var action = " <a class='link' onclick='GCT.SiteLink(this);' data-type='gccollab_opportunity' href='" + value.url + "'>" + GCTLang.Trans("web-view") + "</a>";
+                                var fullview = true;
+
+                                var state = '';
+                                if (value.state) { state += value.state; }
+
+                                content += GCTtxt.txtOpps({
+                                    guid: value.guid,
+                                    icon: value.userDetails.iconURL,
+                                    name: value.userDetails.displayName,
+                                    date: prettyDate(value.time_created),
+                                    jobtype: jobtype,
+                                    roletype: roletype,
+                                    title: value.title,
+                                    oppType: oppType,
+                                    description: text,
+                                    all_text: "all_text",
+                                    source: source,
+
+                                    fullview: fullview,
+                                    additionalTitle: GCTLang.Trans("opportunity-details"),
+                                    programArea: programArea,
+                                    numOpportunities: numOpportunities,
+                                    idealStart: idealStart,
+                                    idealComplete: idealComplete,
+                                    deadline: deadline,
+                                    oppVirtual: oppVirtual,
+                                    oppOnlyIn: oppOnlyIn,
+                                    location: location,
+                                    security: security,
+                                    skills: skills,
+                                    languageReq: languageReq,
+                                    schedulingReq: schedulingReq,
+                                    timezone: timezone,
+                                    timecommitment: timecommitment,
+                                    participants: participants,
+                                    applicants: applicants,
+                                    state: state,
+                                    type: "gccollab_opportunity",
+                                    action: action,
+                                    owner: value.owner_guid,
+                                    liked: liked,
+                                    likes: likes
+                                });
+                            });
+
+                            $(content).hide().appendTo('#content-entity-' + guid).fadeIn(500);
+                        });
+                        break;
                     default:
                         break;
                 }

--- a/www/pages/entity-template.html
+++ b/www/pages/entity-template.html
@@ -161,7 +161,7 @@
                                     var likes = (value.likes > 0) ? value.likes + (value.likes == 1 ? GCTLang.Trans("like") : GCTLang.Trans("likes")) : GCTLang.Trans("like");
                                     var action = '';
 
-                                    content += GCTtxt.txtDiscussion({
+                                    content += GCTtxt.Discussion({
                                         icon: value.userDetails.iconURL,
                                         name: value.userDetails.displayName,
                                         date: prettyDate(value.time_created),
@@ -261,7 +261,7 @@
                                 var state = '';
                                 if (value.state) { state += value.state; }
 
-                                content += GCTtxt.txtOpps({
+                                content += GCTtxt.Opps({
                                     guid: value.guid,
                                     icon: value.userDetails.iconURL,
                                     name: value.userDetails.displayName,
@@ -320,7 +320,7 @@
                                     posted = GCTLang.Trans("posted-user") + " <a onclick='ShowProfile(" + value.owner_guid + ")' >" + value.userDetails.displayName + "</a>";
                                 }
                                 var address = "<a class='external' data-type='gccollab_bookmark' href='" + value.address + "'>" + value.address + "</a> ";
-                                content += GCTtxt.txtBookmark({
+                                content += GCTtxt.Bookmark({
                                     icon: value.userDetails.iconURL,
                                     name: value.userDetails.displayName,
                                     owner: value.owner_guid,
@@ -334,7 +334,7 @@
                                     action: action,
                                     liked: liked,
                                     likes: likes
-                                })
+                                });
                             });
                             $(content).hide().appendTo('#content-entity-' + guid).fadeIn(500);
                         });

--- a/www/pages/entity-template.html
+++ b/www/pages/entity-template.html
@@ -15,7 +15,7 @@
             </div>
 
             <div class="page-content" style="overflow-x: hidden;">
-                <div id="content-entity-{{guid}}"></div>
+                <div id="content-entity-{{guid}}" class='list cards-list'></div>
                 {{#js_if "this.comments"}}
                 <div id="comment-card-{{guid}}">
                     <div class="content-block comment">

--- a/www/pages/entity-template.html
+++ b/www/pages/entity-template.html
@@ -1,0 +1,47 @@
+<template>
+    <div class="page navbar-fixed">
+        <div class="navbar">
+            <div class="entity-{{guid}}-navbar-inner" role="navigation" data-translate-target="aria-label" data-translate="navigation-bar">
+                {{navbar}}
+            </div>
+        </div>
+    </div>
+    <div class="toolbar toolbar-bottom" role="navigation" data-translate-target="aria-label" data-translate="toolbar">
+        <div class="toolbar-inner">
+            <div class="left sliding"><a href="#" class="link back" aria-label="Back Button"><i class="fa fa-arrow-circle-o-left fa-2x"></i></a></div>
+        </div>
+    </div>
+    <div class="page with-subnavbar" style="overflow-x: hidden;">
+        <div id="content-entity-{{guid}}"></div>
+        <div id="comment-card-{{guid}}">
+            <div class="content-block comment">
+                <div class="content-block-inner comment">
+                    <div class="row no-gutter">
+                        <div class="col">
+                            <div id="comment-count-{{guid}}" class="left number-comment" data-translate="comments">comments:</div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="list">
+            <ul class="message-comment">
+                <li class="align-top">
+                    <div class="item-content">
+                        <div class="item-inner">
+                            <div class="item-input">
+                                <textarea id="message-{{guid}}" class="comment-textarea" data-translate-target="placeholder" data-translate="write-comment" placeholder="write a comment"></textarea>
+                            </div>
+                        </div>
+                    </div>
+                </li>
+                <li class="content-block"> <a id="comments-submit-{{guid}}" class="button button-big button-fill" data-translate="comment">Comment</a> </li>
+                <li class="content-block"><a id="comments-view-{{guid}}" class="button button-big button-fill" data-translate="view-comments">VIEW COMMENTS</a></li>
+            </ul>
+        </div>
+        <div id="comment-head" class="list media-list comment">
+            <ul id="entity-comments-{{guid}}" class="comment"></ul>
+            <a id="comments-more-{{guid}}" class="button button-big button-fill" data-translate="view-more">VIEW MORE</a>
+        </div>
+    </div>
+</template>

--- a/www/pages/entity-template.html
+++ b/www/pages/entity-template.html
@@ -1,47 +1,84 @@
 <template>
     <div class="page navbar-fixed">
         <div class="navbar">
-            <div class="entity-{{guid}}-navbar-inner" role="navigation" data-translate-target="aria-label" data-translate="navigation-bar">
-                {{navbar}}
-            </div>
-        </div>
-    </div>
-    <div class="toolbar toolbar-bottom" role="navigation" data-translate-target="aria-label" data-translate="toolbar">
-        <div class="toolbar-inner">
-            <div class="left sliding"><a href="#" class="link back" aria-label="Back Button"><i class="fa fa-arrow-circle-o-left fa-2x"></i></a></div>
-        </div>
-    </div>
-    <div class="page with-subnavbar" style="overflow-x: hidden;">
-        <div id="content-entity-{{guid}}"></div>
-        <div id="comment-card-{{guid}}">
-            <div class="content-block comment">
-                <div class="content-block-inner comment">
-                    <div class="row no-gutter">
-                        <div class="col">
-                            <div id="comment-count-{{guid}}" class="left number-comment" data-translate="comments">comments:</div>
-                        </div>
-                    </div>
+            <div class="navbar-inner">
+                <div id="entity-{{guid}}-navbar-inner" class="navbar-inner" role="navigation" data-translate-target="aria-label" data-translate="navigation-bar">
+                    {{navbar}}
                 </div>
             </div>
         </div>
-        <div class="list">
-            <ul class="message-comment">
-                <li class="align-top">
-                    <div class="item-content">
-                        <div class="item-inner">
-                            <div class="item-input">
-                                <textarea id="message-{{guid}}" class="comment-textarea" data-translate-target="placeholder" data-translate="write-comment" placeholder="write a comment"></textarea>
+
+            <div class="toolbar toolbar-bottom-md">
+                <div class="toolbar-inner">
+                    <div class="left sliding"><a href="#" class="link back" aria-label="Back Button"><i class="far fa-arrow-alt-circle-left fa-2x"></i></a></div>
+                </div>
+            </div>
+
+            <div class="page-content" style="overflow-x: hidden;">
+                <div id="content-entity-{{guid}}"></div>
+                {{#js_if "this.comments"}}
+                <div id="comment-card-{{guid}}">
+                    <div class="content-block comment">
+                        <div class="content-block-inner comment">
+                            <div class="row no-gutter">
+                                <div class="col">
+                                    <div id="comment-count-{{guid}}" class="left number-comment" data-translate="comments">comments:</div>
+                                </div>
                             </div>
                         </div>
                     </div>
-                </li>
-                <li class="content-block"> <a id="comments-submit-{{guid}}" class="button button-big button-fill" data-translate="comment">Comment</a> </li>
-                <li class="content-block"><a id="comments-view-{{guid}}" class="button button-big button-fill" data-translate="view-comments">VIEW COMMENTS</a></li>
-            </ul>
+                </div>
+                <div class="list">
+                    <ul class="message-comment">
+                        <li class="align-top">
+                            <div class="item-content">
+                                <div class="item-inner">
+                                    <div class="item-input">
+                                        <textarea id="message-{{guid}}" class="comment-textarea" data-translate-target="placeholder" data-translate="write-comment" placeholder="write a comment"></textarea>
+                                    </div>
+                                </div>
+                            </div>
+                        </li>
+                        <li class="content-block"> <a id="comments-submit-{{guid}}" class="button button-big button-fill" data-translate="comment">Comment</a> </li>
+                        <li class="content-block"><a id="comments-view-{{guid}}" class="button button-big button-fill" data-translate="view-comments">VIEW COMMENTS</a></li>
+                    </ul>
+                </div>
+                <div id="comment-head" class="list media-list comment">
+                    <ul id="entity-comments-{{guid}}" class="comment"></ul>
+                    <a id="comments-more-{{guid}}" class="button button-big button-fill" data-translate="view-more">VIEW MORE</a>
+                </div>
+                {{/js_if}}
+            </div>
         </div>
-        <div id="comment-head" class="list media-list comment">
-            <ul id="entity-comments-{{guid}}" class="comment"></ul>
-            <a id="comments-more-{{guid}}" class="button button-big button-fill" data-translate="view-more">VIEW MORE</a>
-        </div>
-    </div>
 </template>
+<script>
+    return {
+        on: {
+            pageInit: function (e, page) {
+                var guid = this.guid;
+                var type = this.type;
+                var each = this.each;
+                var limit = 10;
+                var offset = 0;
+                console.log(guid + ' ' + type);
+
+                switch (type) {
+                    case 'wire':
+                        GCTrequests.GetWire(guid, 1, function (data) {
+                            var wires = data.result.reverse();
+                            var content = "";
+                            $(wires).each(function (key, value) {
+                                content += each(value);
+                            });
+                            $(content).hide().appendTo('#content-entity-'+guid).fadeIn(500);
+                        });
+                        break;
+                    default:
+                        break;
+                }
+            },
+
+           
+        }
+    }
+</script>

--- a/www/pages/entity-template.html
+++ b/www/pages/entity-template.html
@@ -437,7 +437,7 @@
                                 content += endOfContent;
                             }
                         } else {
-                            content += noContent;
+                            content += endOfContent;
                             $("#comments-more-" + guid).hide();
                         }
                         $(content).hide().appendTo("#entity-comments-"+ guid).fadeIn(500);

--- a/www/pages/entity-template.html
+++ b/www/pages/entity-template.html
@@ -55,13 +55,14 @@
     return {
         on: {
             pageInit: function (e, page) {
+               
                 var guid = this.guid;
                 var type = this.type;
                 var each = this.each;
                 var limit = 10;
                 var offset = 0;
                 console.log(guid + ' ' + type);
-
+                $("#comments-more-"+ guid).hide();
                 
                 switch (type) {
                     case 'wire':
@@ -144,6 +145,44 @@
                                 });
                             });
 
+                            $(content).hide().appendTo('#content-entity-' + guid).fadeIn(500);
+                        });
+                        break;
+                    case 'discussion':
+                        GCTrequests.GetDiscussion(guid, function (data) {
+                            var discussion = data.result;
+                            var content = "";
+                            $(discussion).each(function (key, value) {
+                                if (value.subtype == "groupforumtopic") {
+                                    // Removes HTML components from Discussion
+                                    var text = (value.description !== null) ? value.description : "";
+                                    var group = GCTLang.Trans("posted-user") + " <a onclick='ShowProfile(" + value.owner_guid + ")' >" + value.userDetails.displayName + "</a>";
+                                    var replied = (value.replied) ? "replied" : "";
+                                    var liked = (value.liked) ? "liked" : "";
+                                    var likes = (value.likes > 0) ? value.likes + (value.likes == 1 ? GCTLang.Trans("like") : GCTLang.Trans("likes")) : GCTLang.Trans("like");
+                                    var action = '';
+
+                                    content += GCTtxt.txtDiscussion({
+                                        icon: value.userDetails.iconURL,
+                                        name: value.userDetails.displayName,
+                                        date: prettyDate(value.time_created),
+                                        group: group,
+                                        description: text,
+                                        title: value.title,
+                                        all_text: "all_text",
+                                        action: action,
+                                        owner: value.owner_guid,
+                                        guid: value.guid,
+                                        type: "gccollab_discussion_post",
+                                        replied: replied,
+                                        liked: liked,
+                                        likes: likes
+                                    });
+                                } else if (value.subtype == "discussion_reply") {
+                                    //not needed
+                                }
+
+                            });
                             $(content).hide().appendTo('#content-entity-' + guid).fadeIn(500);
                         });
                         break;

--- a/www/pages/entity-template.html
+++ b/www/pages/entity-template.html
@@ -62,13 +62,49 @@
                 var offset = 0;
                 console.log(guid + ' ' + type);
 
+                
                 switch (type) {
                     case 'wire':
                         GCTrequests.GetWire(guid, 1, function (data) {
                             var wires = data.result.reverse();
                             var content = "";
                             $(wires).each(function (key, value) {
-                                content += each(value);
+                                // Removes HTML components from Blog
+                                // var text = $(value.description).text();
+                                var text = value.description;
+
+                                var source = "";
+                                if (value.shareText && value.shareURL) {
+                                    source = "<blockquote>" + GCTLang.Trans("source") + " <a onclick='GCT.FireLink(this);' data-type='gccollab_wire_post' href='" + value.shareURL + "'>" + value.shareText + "</a></blockquote>";
+                                } else if (value.shareURL) {
+                                    source = "<blockquote>" + GCTLang.Trans("source") + " <a onclick='GCT.FireLink(this);' data-type='gccollab_wire_post' href='" + value.shareURL + "'>" + text + "</a></blockquote>";
+                                }
+                                var img = '';
+                                var img = '';
+                                if (value.attachment) {
+                                    img = "<img class='WireImage' onclick='ShowImage(this)' id='image-" + value.guid + "' src='https://gccollab.ca/thewire_image/download/" + value.attachment.guid + "' style='' />";
+                                }
+
+                                var replied = (value.replied) ? "replied" : "";
+                                var liked = (value.liked) ? "liked" : "";
+                                var likes = (value.likes > 0) ? value.likes + (value.likes == 1 ? GCTLang.Trans("like") : GCTLang.Trans("likes")) : GCTLang.Trans("like");
+                                var action = '';
+
+                                content += GCTtxt.txtWire({
+                                    guid: value.guid,
+                                    icon: value.userDetails.iconURL,
+                                    name: value.userDetails.displayName,
+                                    date: prettyDate(value.time_created),
+                                    description: text,
+                                    source: source,
+                                    type: "gccollab_wire_post",
+                                    replied: replied,
+                                    action: action,
+                                    owner: value.owner_guid,
+                                    liked: liked,
+                                    likes: likes,
+                                    image: img
+                                });
                             });
                             $(content).hide().appendTo('#content-entity-'+guid).fadeIn(500);
                         });

--- a/www/pages/entity-template.html
+++ b/www/pages/entity-template.html
@@ -126,7 +126,7 @@
                                 var likes = (value.likes > 0) ? value.likes + (value.likes == 1 ? GCTLang.Trans("like") : GCTLang.Trans("likes")) : GCTLang.Trans("like");
                                 var action = " <a class='link' onclick='GCT.SiteLink(this);' data-type='gccollab_blog_post' href='" + value.url + "'>" + GCTLang.Trans("web-view") + "</a>";
 
-                                content += GCTtxt.txtBlog({
+                                content += GCTtxt.Blog({
                                     icon: value.userDetails.iconURL,
                                     name: value.userDetails.displayName,
                                     date: prettyDate(value.time_created),
@@ -388,7 +388,7 @@
                                 if (value.eventLang !== null && typeof value.eventLang !== 'undefined')
                                     eventLang += value.eventLang;
 
-                                content = GCTtxt.txtEvent({
+                                content = GCTtxt.Event({
                                     icon: value.userDetails.iconURL,
                                     name: value.userDetails.displayName,
                                     startDate: startDate,

--- a/www/pages/entity-template.html
+++ b/www/pages/entity-template.html
@@ -340,6 +340,85 @@
                             $(content).hide().appendTo('#content-entity-' + guid).fadeIn(500);
                         });
                         break;
+                    case 'event':
+                        GCTrequests.GetEvent(guid, function (data) {
+                            var event = data.result;
+                            var content = "";
+
+                            $(event).each(function (key, value) {
+                                var text = (value.description !== null) ? value.description : "";
+
+                                var liked = (value.liked) ? "liked" : "";
+                                var likes = (value.likes > 0) ? value.likes + (value.likes == 1 ? GCTLang.Trans("like") : GCTLang.Trans("likes")) : GCTLang.Trans("like");
+                                var action = " <a class='link' onclick='GCT.SiteLink(this);' data-type='gccollab_event' href='" + value.url + "'>" + GCTLang.Trans("web-view") + "</a>";
+
+                                var date = (value.startDate).split(" ")[0];
+                                var split = date.split("-");
+                                var day = new Date(split[0], parseInt(split[1]) - 1, split[2]);
+                                var month = parseInt(split[1]) - 1;
+                                var id = 'event-' + split[0] + '-' + month + '-' + split[2];
+                                id = id.replace(/(^|-)0+/g, "$1");
+
+                                var posted = "";
+                                if (value.groupGUID !== null && typeof value.groupGUID !== 'undefined') {
+                                    posted = GCTLang.Trans("posted-group") + "<a class='link' data-guid='" + value.groupGUID + "' data-type='gccollab_group' onclick='GCTUser.ViewPost(this);'>" + value.group + "</a>";
+                                } else {
+                                    posted = GCTLang.Trans("posted-user") + " <a onclick='ShowProfile(" + value.owner_guid + ")' >" + value.userDetails.displayName + "</a>";
+                                }
+
+                                var startDate = GCTLang.Trans("start-date") + date;
+                                var endDate = GCTLang.Trans("end-date") + (value.endDate).split(" ")[0];
+
+                                var location = ((value.location !== null) && (typeof value.location !== 'undefined')) ? "<b>" + GCTLang.Trans("location") + "</b>" + value.location : "";
+
+                                var fullview = true;
+                                var additionalTitle = GCTLang.Trans("additional-info");
+                                var org = GCTLang.Trans("organizer");
+                                if (value.organizer !== null && typeof value.organizer !== 'undefined')
+                                    org += value.organizer;
+                                var phone = GCTLang.Trans("phone") + ": ";
+                                if (value.phone !== null && typeof value.phone !== 'undefined')
+                                    phone += value.phone;
+                                var email = GCTLang.Trans("email") + ": ";
+                                if (value.email !== null && typeof value.email !== 'undefined')
+                                    email += value.email;
+                                var fee = GCTLang.Trans("fee");
+                                if (value.fee !== null && typeof value.fee !== 'undefined')
+                                    fee += value.fee;
+                                var eventLang = GCTLang.Trans("lang");
+                                if (value.eventLang !== null && typeof value.eventLang !== 'undefined')
+                                    eventLang += value.eventLang;
+
+                                content = GCTtxt.txtEvent({
+                                    icon: value.userDetails.iconURL,
+                                    name: value.userDetails.displayName,
+                                    startDate: startDate,
+                                    endDate: endDate,
+                                    date: prettyDate(value.startDate),
+                                    location: location,
+                                    posted: posted,
+                                    description: text,
+                                    title: value.title,
+                                    id: id,
+                                    action: action,
+                                    owner: value.owner_guid,
+                                    guid: value.guid,
+                                    all_text: "all_text",
+                                    type: "gccollab_event",
+                                    liked: liked,
+                                    likes: likes,
+                                    fullview: fullview,
+                                    additionalTitle: additionalTitle,
+                                    org: org,
+                                    phone: phone,
+                                    email: email,
+                                    fee: fee,
+                                    eventLang: eventLang
+                                });
+                            });
+                            $(content).hide().appendTo('#content-entity-' + guid).fadeIn(500);
+                        });
+                        break;
                     default:
                         break;
                 }

--- a/www/pages/entity-template.html
+++ b/www/pages/entity-template.html
@@ -305,6 +305,41 @@
                             $(content).hide().appendTo('#content-entity-' + guid).fadeIn(500);
                         });
                         break;
+                    case 'bookmark':
+                        GCTrequests.GetBookmark(guid, function (data) {
+                            var bookmark = data.result;
+                            var content = "";
+                            $(bookmark).each(function (key, value) {
+                                var liked = (value.liked) ? "liked" : "";
+                                var likes = (value.likes > 0) ? value.likes + (value.likes == 1 ? GCTLang.Trans("like") : GCTLang.Trans("likes")) : GCTLang.Trans("like");
+                                var action = '';
+                                var action = " <a class='link' onclick='GCT.SiteLink(this);' data-type='gccollab_bookmark' href='" + value.url + "'>" + GCTLang.Trans("web-view") + "</a>";
+                                var posted = '';
+                                if (value.group_guid) {
+                                    posted = GCTLang.Trans("posted-group") + "<a class='link' data-guid='" + value.group_guid + "' data-type='gccollab_group' onclick='GCTUser.ViewPost(this);'>" + value.group + "</a>";
+                                } else {
+                                    posted = GCTLang.Trans("posted-user") + " <a onclick='ShowProfile(" + value.owner_guid + ")' >" + value.userDetails.displayName + "</a>";
+                                }
+                                var address = "<a class='external' data-type='gccollab_bookmark' href='" + value.address + "'>" + value.address + "</a> ";
+                                content += GCTtxt.txtBookmark({
+                                    icon: value.userDetails.iconURL,
+                                    name: value.userDetails.displayName,
+                                    owner: value.owner_guid,
+                                    date: prettyDate(value.time_created),
+                                    title: value.title,
+                                    posted: posted,
+                                    description: value.description,
+                                    address: address,
+                                    type: "gccollab_bookmark",
+                                    guid: value.guid,
+                                    action: action,
+                                    liked: liked,
+                                    likes: likes
+                                })
+                            });
+                            $(content).hide().appendTo('#content-entity-' + guid).fadeIn(500);
+                        });
+                        break;
                     default:
                         break;
                 }

--- a/www/pages/entity-template.html
+++ b/www/pages/entity-template.html
@@ -109,6 +109,44 @@
                             $(content).hide().appendTo('#content-entity-'+guid).fadeIn(500);
                         });
                         break;
+                    case 'blog':
+                        GCTrequests.GetBlog(guid, function (data) {
+                            var blog = data.result;
+                            var content = "";
+                            $(blog).each(function (key, value) {
+                                // Removes HTML components from Blog
+                                var text = (value.description !== null) ? value.description : "";
+                                if (value.groupURL.indexOf("/groups/profile/") > -1) {
+                                    var group = GCTLang.Trans("posted-group") + " <a onclick='GCT.FireLink(this);' data-type='gccollab_group' href='" + value.groupURL + "'>" + value.group + "</a>";
+                                } else {
+                                    var group = GCTLang.Trans("posted-user") + " <a onclick='ShowProfile(" + value.owner_guid + ")' >" + value.userDetails.displayName + "</a>";
+                                }
+                                var replied = (value.replied) ? "replied" : "";
+                                var liked = (value.liked) ? "liked" : "";
+                                var likes = (value.likes > 0) ? value.likes + (value.likes == 1 ? GCTLang.Trans("like") : GCTLang.Trans("likes")) : GCTLang.Trans("like");
+                                var action = " <a class='link' onclick='GCT.SiteLink(this);' data-type='gccollab_blog_post' href='" + value.url + "'>" + GCTLang.Trans("web-view") + "</a>";
+
+                                content += GCTtxt.txtBlog({
+                                    icon: value.userDetails.iconURL,
+                                    name: value.userDetails.displayName,
+                                    date: prettyDate(value.time_created),
+                                    group: group,
+                                    description: text,
+                                    title: value.title,
+                                    all_text: "all_text",
+                                    action: action,
+                                    owner: value.owner_guid,
+                                    guid: value.guid,
+                                    type: "gccollab_blog_post",
+                                    replied: replied,
+                                    liked: liked,
+                                    likes: likes
+                                });
+                            });
+
+                            $(content).hide().appendTo('#content-entity-' + guid).fadeIn(500);
+                        });
+                        break;
                     default:
                         break;
                 }

--- a/www/pages/entity-template.html
+++ b/www/pages/entity-template.html
@@ -463,6 +463,20 @@
                         $(content).hide().appendTo("#entity-comments-" + guid).fadeIn(500);
                     });
                 });
+                $$('#comments-submit-' + guid).on('click', function (e) {
+                    var comment = $$('#message-' + guid).val();
+                    if (!(comment === '')) {
+                        GCTrequests.SubmitComment(guid, comment, function (data) {
+                            console.log("submited");
+                            var result = data.result;
+                            console.log(result);
+                        }, function (jqXHR, textStatus, errorThrown) {
+                            console.log(jqXHR, textStatus, errorThrown);
+                        });
+                    } else {
+                        //empty message, dont use, give feedback
+                    }
+                });
             },
 
            

--- a/www/pages/entity-template.html
+++ b/www/pages/entity-template.html
@@ -55,10 +55,9 @@
     return {
         on: {
             pageInit: function (e, page) {
-               
                 var guid = this.guid;
                 var type = this.type;
-                var each = this.each;
+                var comments = this.comments;
                 var limit = 10;
                 var offset = 0;
                 console.log(guid + ' ' + type);
@@ -422,6 +421,48 @@
                     default:
                         break;
                 }
+
+                $$('#comments-view-'+guid).on('click', function (e) {
+                    GCTrequests.GetComments(guid, limit, offset, function (data) {
+                        $("#comments-view-" + guid).hide();
+                        $("#comments-more-" + guid).show();
+                        var comments = data.result;
+                        var content = "";
+                        if (comments.length > 0) {
+                            $(comments).each(function (key, value) {
+                                content += GCTEach.Comment(value);
+                            });
+                            if (comments.length < limit) {
+                                $("#comments-more-" + guid).hide();
+                                content += endOfContent;
+                            }
+                        } else {
+                            content += noContent;
+                            $("#comments-more-" + guid).hide();
+                        }
+                        $(content).hide().appendTo("#entity-comments-"+ guid).fadeIn(500);
+                    });
+                });
+                $$('#comments-more-'+guid).on('click', function (e) {
+                    GCTrequests.GetComments(guid, limit, offset + limit, function (data) {
+                        offset += limit;
+                        var comments = data.result;
+                        var content = "";
+                        if (comments.length > 0) {
+                            $(comments).each(function (key, value) {
+                                content += GCTEach.Comment(value);
+                            });
+                            if (comments.length < limit) {
+                                content += endOfContent;
+                                $("#comments-more-" + guid).hide();
+                            }
+                        } else {
+                            content += endOfContent;
+                            $("#comments-more-" + guid).hide();
+                        }
+                        $(content).hide().appendTo("#entity-comments-" + guid).fadeIn(500);
+                    });
+                });
             },
 
            

--- a/www/pages/entity-template.html
+++ b/www/pages/entity-template.html
@@ -90,7 +90,7 @@
                                 var likes = (value.likes > 0) ? value.likes + (value.likes == 1 ? GCTLang.Trans("like") : GCTLang.Trans("likes")) : GCTLang.Trans("like");
                                 var action = '';
 
-                                content += GCTtxt.txtWire({
+                                content += GCTtxt.Wire({
                                     guid: value.guid,
                                     icon: value.userDetails.iconURL,
                                     name: value.userDetails.displayName,


### PR DESCRIPTION
Migrated all entities via Entity-Template: closes #244 
Migrated Comments: closes #253 

Entity-Template for most entities (not docs). Takes type and guid in route. 
Migrated Get___ functions for each content type.
Switch inside Entity-Template handles variables, rather than ContentSuccess because of differences in the card vs full entity, such as labels and item-link. Expanding that, also created separate GCTtxt functions to handle full entity. Will be refined later.
Migrated comments for Entity-Template. View, More, and Submit. 
Doc entity has own page. Route, template, and ViewPost case.
App data for each entity type.