### PR TITLE
Event Calendar Migration w Tabs

### DIFF
--- a/www/js/GCT.js
+++ b/www/js/GCT.js
@@ -2147,6 +2147,45 @@ GCTrequests = {
             }
         });
     },
+    GetEventsByUser: function (tabObject, from, to) {
+        limit = tabObject.limit || 15;
+        // offset = offset || 0;
+        from = from || "";
+        to = to || "";
+
+        app.request({
+            method: 'POST',
+            dataType: 'json',
+            url: GCT.GCcollabURL,
+            data: { method: "get.eventsbyowner", user: GCTUser.Email(), from: from, to: to, limit: limit, api_key: api_key_gccollab, lang: GCTLang.Lang() },
+            timeout: 12000,
+            success: function (data) {
+                GCTEach.ContentSuccessEvent(data, tabObject);
+            },
+            error: function (jqXHR, textStatus, errorThrown) {
+                errorConsole(jqXHR, textStatus, errorThrown);
+            }
+        });
+    },
+    GetEventsByColleagues: function (tabObject, from, to) {
+        limit = tabObject.limit || 15;
+        from = from || "";
+        to = to || "";
+
+        app.request({
+            method: 'POST',
+            dataType: 'json',
+            url: GCT.GCcollabURL,
+            data: { method: "get.eventsbycolleagues", user: GCTUser.Email(), from: from, to: to, limit: limit, api_key: api_key_gccollab, lang: GCTLang.Lang() },
+            timeout: 12000,
+            success: function (data) {
+                GCTEach.ContentSuccessEvent(data, tabObject);
+            },
+            error: function (jqXHR, textStatus, errorThrown) {
+                errorConsole(jqXHR, textStatus, errorThrown);
+            }
+        });
+    },
     GetBookmark: function (guid, successCallback) {
         app.request({
             method: 'POST',

--- a/www/js/GCT.js
+++ b/www/js/GCT.js
@@ -959,7 +959,7 @@ GCTEach = {
 
 
         var month = parseInt(split[1]) - 1;
-        var id = 'event-' + split[0] + '-' + month + '-' + split[2];
+        var id = 'event-' + value.tab + '-' + split[0] + '-' + month + '-' + split[2];
         id = id.replace(/(^|-)0+/g, "$1");
 
         var posted = "";
@@ -1382,7 +1382,6 @@ GCTEach = {
         if (focusNow) { focusNow.focus(); }
     },
     ContentSuccessEvent: function (data, obj) {
-        console.log(obj);
         var info = data.result;
         var content = '';
         //clear old calendar, destroy and clear
@@ -1403,6 +1402,7 @@ GCTEach = {
                 var split = date.split("-");
                 var day = new Date(split[0], parseInt(split[1]) - 1, split[2]);
                 obj.events.push(day);
+                value.tab = obj.name;
                 content = obj.eachFunc(value);
                 $(content).hide().appendTo('#content-' + obj.id).fadeIn(1000);
             });
@@ -1441,8 +1441,8 @@ GCTEach = {
                     dayClick: function (c, dayEl, year, month, day) {
                         console.log('clicked day');
                         var date = $(dayEl).data('date');
-                        if ($("#event-" + date).length > 0) {
-                            $$('.page-content').scrollTop($$("#event-" + date).offset().top, 300);
+                        if ($("#event-" + obj.name + '-' + date).length > 0) {
+                            $$('.page-content').scrollTop($$("#event-" + obj.name + '-' + date).offset().top, 300);
                         }
                     }
                 }

--- a/www/js/GCT.js
+++ b/www/js/GCT.js
@@ -43,7 +43,7 @@
         }
         return filter;
     },
-    txtTabHeader: function (ref) {
+    txtTabHeader: function (ref, id) {
         var header = '';
         switch (ref) {
             case 'newsfeed':
@@ -56,6 +56,10 @@
             case 'blogs':
                 header = '<div class="block small"><div class="row"><div class="col-66"><h2 class="no-margin" data-translate="blogs" tabindex="0" id="tabheader-home-wire">' + GCTLang.Trans("blogs") + '</h2></div>'
                     + '<div class="col-33"><a href="/list-template/blogs/" class="button button-fill pull-right" >' + GCTLang.Trans("view-all") + '</a></div></div></div>';
+                break;
+            case 'event':
+                header = 'yes' + id;
+                break;
             default: ;
         }
         return header;
@@ -2447,7 +2451,7 @@ function tabObject(page, tab, limit, type, header, eachFunc, request) {
         type: type,
         name: tab,
         page: page,
-        header: GCTtxt.txtTabHeader(header),
+        header: GCTtxt.txtTabHeader(header, page + '-' + tab),
         appendMessage: GCTtxt.txtFocusMessage(page + '-' + tab),
         eachFunc: eachFunc,
         request: request,

--- a/www/js/GCT.js
+++ b/www/js/GCT.js
@@ -1385,6 +1385,8 @@ GCTEach = {
         console.log(obj);
         var info = data.result;
         var content = '';
+        //clear old calendar, destroy and clear
+        if (obj.calendar) { obj.calendar.destroy(); $('#event-calendar-' + obj.id).html(''); }
 
         var monthNames = "";
         if (GCTLang.IsEnglish()) {
@@ -1400,12 +1402,11 @@ GCTEach = {
                 var date = (value.startDate).split(" ")[0];
                 var split = date.split("-");
                 var day = new Date(split[0], parseInt(split[1]) - 1, split[2]);
-                console.log(day);
                 obj.events.push(day);
                 content = obj.eachFunc(value);
                 $(content).hide().appendTo('#content-' + obj.id).fadeIn(1000);
             });
-            var calendar = app.calendar.create({
+            obj.calendar = app.calendar.create({
                 containerEl: '#event-calendar-' + obj.id,
                 value: [new Date()],
                 weekHeader: false,
@@ -1428,10 +1429,10 @@ GCTEach = {
                     init: function (c) {
                         $$('.calendar-custom-toolbar .center').text(monthNames[c.currentMonth] + ', ' + c.currentYear);
                         $$('.calendar-custom-toolbar .left .link').on('click', function () {
-                            calendar.prevMonth();
+                            obj.calendar.prevMonth();
                         });
                         $$('.calendar-custom-toolbar .right .link').on('click', function () {
-                            calendar.nextMonth();
+                            obj.calendar.nextMonth();
                         });
                     },
                     monthYearChangeStart: function (c) {

--- a/www/js/GCT.js
+++ b/www/js/GCT.js
@@ -58,7 +58,7 @@
                     + '<div class="col-33"><a href="/list-template/blogs/" class="button button-fill pull-right" >' + GCTLang.Trans("view-all") + '</a></div></div></div>';
                 break;
             case 'event':
-                header = '<div id="event-calendar-'+ id +'"></div>';
+                header = '<div id="event-calendar-' + id +'" aria-hidden="true"></div>';
                 break;
             default: ;
         }

--- a/www/js/GCT.js
+++ b/www/js/GCT.js
@@ -58,7 +58,7 @@
                     + '<div class="col-33"><a href="/list-template/blogs/" class="button button-fill pull-right" >' + GCTLang.Trans("view-all") + '</a></div></div></div>';
                 break;
             case 'event':
-                header = 'yes' + id;
+                header = '<div id="event-calendar-'+ id +'"></div>';
                 break;
             default: ;
         }

--- a/www/js/GCT.js
+++ b/www/js/GCT.js
@@ -1437,6 +1437,13 @@ GCTEach = {
                     },
                     monthYearChangeStart: function (c) {
                         $$('.calendar-custom-toolbar .center').text(monthNames[c.currentMonth] + ', ' + c.currentYear);
+                    },
+                    dayClick: function (c, dayEl, year, month, day) {
+                        console.log('clicked day');
+                        var date = $(dayEl).data('date');
+                        if ($("#event-" + date).length > 0) {
+                            $$('.page-content').scrollTop($$("#event-" + date).offset().top, 300);
+                        }
                     }
                 }
             });

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -55,7 +55,7 @@ var app  = new Framework7({
             },
             events: {
                 limit: 15,
-                tabs: [{ id: "all", each: GCTEach.Event, request: GCTrequests.GetEvents, type: 'card' }],
+                tabs: [{ id: "all", each: GCTEach.Event, request: GCTrequests.GetEvents, type: 'card', header: 'event' }],
                 action: '',
                 filters: '',
             },

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -55,7 +55,9 @@ var app  = new Framework7({
             },
             events: {
                 limit: 15,
-                tabs: [{ id: "all", each: GCTEach.Event, request: GCTrequests.GetEvents, type: 'card', header: 'event' }],
+                tabs: [{ id: "all", each: GCTEach.Event, request: GCTrequests.GetEvents, type: 'card', header: 'event' },
+                    { id: "my-colleagues", each: GCTEach.Event, request: GCTrequests.GetEventsByColleagues, type: 'card', header: 'event' },
+                    { id: "mine", each: GCTEach.Event, request: GCTrequests.GetEventsByUser, type: 'card', header: 'event' }],
                 action: '',
                 filters: '',
             },

--- a/www/pages/list-template.html
+++ b/www/pages/list-template.html
@@ -101,6 +101,46 @@
                             tab.request(tab);
                         }
                     });
+                    if (tab.page == 'events' && tab.header != '') {
+                        var monthNames = "";
+                        if (GCTLang.IsEnglish()) {
+                            monthNames = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
+                        } else {
+                            monthNames = ['janvier', 'février', 'mars', 'avril', 'mai', 'juin', 'juillet', 'août', 'septembre', 'octobre', 'novembre', 'décembre'];
+                        }
+                        var calendarInline = app.calendar.create({
+                            containerEl: '#event-calendar-'+tab.id,
+                            value: [new Date()],
+                            weekHeader: false,
+                            renderToolbar: function () {
+                                return '<div class="toolbar calendar-custom-toolbar no-shadow">' +
+                                    '<div class="toolbar-inner">' +
+                                    '<div class="left">' +
+                                    '<a href="#" class="link icon-only"><i class="icon icon-back ' + (app.theme === 'md' ? 'color-black' : '') + '"></i></a>' +
+                                    '</div>' +
+                                    '<div class="center"></div>' +
+                                    '<div class="right">' +
+                                    '<a href="#" class="link icon-only"><i class="icon icon-forward ' + (app.theme === 'md' ? 'color-black' : '') + '"></i></a>' +
+                                    '</div>' +
+                                    '</div>' +
+                                    '</div>';
+                            },
+                            on: {
+                                init: function (c) {
+                                    $$('.calendar-custom-toolbar .center').text(monthNames[c.currentMonth] + ', ' + c.currentYear);
+                                    $$('.calendar-custom-toolbar .left .link').on('click', function () {
+                                        calendarInline.prevMonth();
+                                    });
+                                    $$('.calendar-custom-toolbar .right .link').on('click', function () {
+                                        calendarInline.nextMonth();
+                                    });
+                                },
+                                monthYearChangeStart: function (c) {
+                                    $$('.calendar-custom-toolbar .center').text(monthNames[c.currentMonth] + ', ' + c.currentYear);
+                                }
+                            }
+                        });
+                    }
                 });
                 //Refresh Button - All
                 $$('#refresh-' + this.page).on('click', function (e) {

--- a/www/pages/list-template.html
+++ b/www/pages/list-template.html
@@ -101,46 +101,6 @@
                             tab.request(tab);
                         }
                     });
-                    if (tab.page == 'events' && tab.header != '') {
-                        var monthNames = "";
-                        if (GCTLang.IsEnglish()) {
-                            monthNames = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
-                        } else {
-                            monthNames = ['janvier', 'février', 'mars', 'avril', 'mai', 'juin', 'juillet', 'août', 'septembre', 'octobre', 'novembre', 'décembre'];
-                        }
-                        var calendarInline = app.calendar.create({
-                            containerEl: '#event-calendar-'+tab.id,
-                            value: [new Date()],
-                            weekHeader: false,
-                            renderToolbar: function () {
-                                return '<div class="toolbar calendar-custom-toolbar no-shadow">' +
-                                    '<div class="toolbar-inner">' +
-                                    '<div class="left">' +
-                                    '<a href="#" class="link icon-only"><i class="icon icon-back ' + (app.theme === 'md' ? 'color-black' : '') + '"></i></a>' +
-                                    '</div>' +
-                                    '<div class="center"></div>' +
-                                    '<div class="right">' +
-                                    '<a href="#" class="link icon-only"><i class="icon icon-forward ' + (app.theme === 'md' ? 'color-black' : '') + '"></i></a>' +
-                                    '</div>' +
-                                    '</div>' +
-                                    '</div>';
-                            },
-                            on: {
-                                init: function (c) {
-                                    $$('.calendar-custom-toolbar .center').text(monthNames[c.currentMonth] + ', ' + c.currentYear);
-                                    $$('.calendar-custom-toolbar .left .link').on('click', function () {
-                                        calendarInline.prevMonth();
-                                    });
-                                    $$('.calendar-custom-toolbar .right .link').on('click', function () {
-                                        calendarInline.nextMonth();
-                                    });
-                                },
-                                monthYearChangeStart: function (c) {
-                                    $$('.calendar-custom-toolbar .center').text(monthNames[c.currentMonth] + ', ' + c.currentYear);
-                                }
-                            }
-                        });
-                    }
                 });
                 //Refresh Button - All
                 $$('#refresh-' + this.page).on('click', function (e) {


### PR DESCRIPTION
Most of the Event Calendar migrated and working. Need API changes to fully test. 

Event page has 3 tabs. Each has their GetEvents function (all, by colleague, by user)
Event has extra logic so has it's own ContentSuccessEvent rather than the default.
Each tab has it's own calendar with it's own dates on it. Day Click goes to that card. Month switching impacts all the tabs, tried to change that but with no success.

