### PR TITLE
Minor Fixes

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -250,6 +250,7 @@
         <div class="popup likes-popup">
             <div class="view">
                 <div class="page">
+                    <div class="reader-text" id="likes-menu" tabindex="0" data-translate="likes"></div>
                     <div class="navbar">
                         <div class="navbar-inner">
                             <div class="left">

--- a/www/index.html
+++ b/www/index.html
@@ -46,9 +46,10 @@
             <div class="view">
                 <div class="page">
                     <div class="page-content">
-                        <div class="item-content userprofile">
-                            <div class="item-media"><a href="#" class="item-link panel-close" onclick="ShowProfile();"><img src="" width="44" alt="" id="imgUserProfilePic" /></a></div>
-                            <div class="item-inner">
+                        <div class="reader-text" id="menu-panel" tabindex="0" data-translate="main-menu">Main Menu</div>
+                        <div class="item-content userprofile item-link panel-close" onclick="ShowProfile();" data-translate-target="aria-label" data-translate="show-user" aria-label="">
+                            <div class="item-media" aria-hidden="true"><img src="" width="44" alt="" id="imgUserProfilePic" /></div>
+                            <div class="item-inner" aria-hidden="true">
                                 <div class="item-title-row">
                                     <div class="item-title" id="divUserProfileName"></div>
                                 </div>

--- a/www/index.html
+++ b/www/index.html
@@ -42,7 +42,7 @@
         <!-- Status bar overlay for fullscreen mode-->
         <div class="statusbar"></div>
         <!-- Left panel with cover effect-->
-        <div class="panel panel-left">
+        <div class="panel panel-left panel-cover">
             <div class="view">
                 <div class="page">
                     <div class="page-content">

--- a/www/js/GCT.js
+++ b/www/js/GCT.js
@@ -2851,7 +2851,8 @@ GCTrequests = {
 
                
                 $('#content-likes').html(content);
-                app.popup.open('.likes-popup')
+                app.popup.open('.likes-popup');
+                $('#likes-menu').focus();
 
             },
             error: function (jqXHR, textStatus, errorThrown) {

--- a/www/js/GCT.js
+++ b/www/js/GCT.js
@@ -3112,6 +3112,9 @@ GCT = {
                 opened: function (popover) {
                     console.log('Popover opened');
                 },
+                closed: function (popover) {
+                    $(obj).focus();
+                },
             }
         });
         optionsPopover.open();

--- a/www/js/GCT.js
+++ b/www/js/GCT.js
@@ -16,7 +16,7 @@
         return content;
     },
     txtFocusMessage: function (id) {
-        return '<span id="focus-' + id + '" style="position: absolute !important; clip: rect(1px, 1px, 1px, 1px);" tabindex="0">' + GCTLang.Trans('content-loaded') + '</span>';
+        return '<span id="focus-' + id + '" class="reader-text" tabindex="0">' + GCTLang.Trans('content-loaded') + '</span>';
     },
     txtAction: function (ref) {
         var action = '';

--- a/www/js/GCT.js
+++ b/www/js/GCT.js
@@ -22,7 +22,7 @@
         var action = '';
         switch (ref) {
             case "post-home":
-                action = '<a id="home-actions" href="#" class="link open-popover" data-popover=".popover-actions" aria-label="Create a new Post Menu Options"><i class="fa fa-plus fa-2x"></i></a>';
+                action = '<a id="home-actions" href="#" class="button popover-open" data-popover=".popover-actions-home" aria-label="Create a new Post Menu Options"><i class="fa fa-plus fa-2x"></i></a>';
                 break;
             case "post-wire":
                 action = '<a href="#" class="link icon-only" onclick="GCTrequests.PostWirePost();"><i class="fas fa-rss fa-2x"></i></a>';

--- a/www/js/gccollab.js
+++ b/www/js/gccollab.js
@@ -250,3 +250,8 @@ $$(document).on('page:init', '.page[data-name="post-opp"]', function (e) {
         }
     });
 })
+
+$$('.panel-left').on('panel:open', function () {
+    var focusTitle = document.getElementById('menu-panel');
+    if (focusTitle) { focusTitle.focus(); }
+});

--- a/www/pages/list-template.html
+++ b/www/pages/list-template.html
@@ -1,47 +1,60 @@
 <template>
     <div class="page navbar-fixed with-subnavbar">
-    <div class="navbar">
-        <div class="navbar-inner">
-            <div id="{{page}}-navbar-inner" class="navbar-inner" role="navigation" data-translate-target="aria-label" data-translate="navigation-bar">
-                {{navbar}}
-            </div>
-            {{#js_if "this.tabs.length != 1" }}
-            <div class="subnavbar" role="navigation" data-translate-target="aria-label">
-                <div class="subnavbar-inner">
-                    <div class="segmented">
-                        {{#each tabs}}
-                        <a href="#tab-{{this.id}}" class="button {{#if @first}}tab-link-active{{/if}} tab-link" data-translate="{{this.name}}"></a>
-                        {{/each}}
+        <div class="navbar">
+            <div class="navbar-inner">
+                <div id="{{page}}-navbar-inner" class="navbar-inner" role="navigation" data-translate-target="aria-label" data-translate="navigation-bar">
+                    {{navbar}}
+                </div>
+                {{#js_if "this.tabs.length != 1" }}
+                <div class="subnavbar" role="navigation" data-translate-target="aria-label">
+                    <div class="subnavbar-inner">
+                        <div class="segmented">
+                            {{#each tabs}}
+                            <a href="#tab-{{this.id}}" class="button {{#if @first}}tab-link-active{{/if}} tab-link" data-translate="{{this.name}}"></a>
+                            {{/each}}
+                        </div>
                     </div>
                 </div>
+                {{/js_if}}
             </div>
-            {{/js_if}}
         </div>
-    </div>
-    <div class="toolbar toolbar-bottom-md">
-        <div class="toolbar-inner">
-            <div class="left sliding"><a href="#" class="link back" aria-label="Back Button"><i class="far fa-arrow-alt-circle-left fa-2x"></i></a></div>
-            <div class="right sliding">{{this.action}}{{this.filter}}</div>
+        <div class="toolbar toolbar-bottom-md">
+            <div class="toolbar-inner">
+                <div class="left sliding"><a href="#" class="link back" aria-label="Back Button"><i class="far fa-arrow-alt-circle-left fa-2x"></i></a></div>
+                <div class="right sliding">{{this.action}}{{this.filter}}</div>
+            </div>
         </div>
-    </div>
 
-    <div class="page with-subnavbar" style="overflow-x: hidden;">
-        <div class="tabs">
-            {{#each tabs}}
-            <div id="tab-{{this.id}}" class="page-content tab {{#if @first}}tab-active{{/if}}">
-                {{this.header}}
-                {{#js_if "this.type == 'card'"}}<div id="content-{{this.id}}" class='list cards-list'></div>{{/js_if}}
-                {{#js_if "this.type == 'item'"}}<div class="list media-list"><ul id="content-{{this.id}}"></ul></div>{{/js_if}}
-                <div class="block">
-                    <div class="row">
-                        <a id="more-{{this.id}}" class="col button button-big button-fill" data-translate="view-more">VIEW MORE</a>
+        <div class="page with-subnavbar" style="overflow-x: hidden;">
+            <div class="tabs">
+                {{#each tabs}}
+                <div id="tab-{{this.id}}" class="page-content tab {{#if @first}}tab-active{{/if}}">
+                    {{this.header}}
+                    {{#js_if "this.type == 'card'"}}<div id="content-{{this.id}}" class='list cards-list'></div>{{/js_if}}
+                    {{#js_if "this.type == 'item'"}}<div class="list media-list"><ul id="content-{{this.id}}"></ul></div>{{/js_if}}
+                    <div class="block">
+                        <div class="row">
+                            <a id="more-{{this.id}}" class="col button button-big button-fill" data-translate="view-more">VIEW MORE</a>
+                        </div>
                     </div>
                 </div>
+                {{/each}}
             </div>
-            {{/each}}
         </div>
+        {{#js_if "this.page === 'home'"}}
+        <div class="popover popover-actions-{{page}}">
+            <div class="popover-inner">
+                <div class="list">
+                    <ul id="popover-actions-{{page}}">
+                        <li><a href="#" onclick="GCTrequests.PostWirePost();" class="list-button item-link popover-close"><i class="fas fa-rss"> <span data-translate="create-wire"></span></i></a></li>
+                        <li><a href="#" onclick="GCTrequests.PostBlogPost();" class="list-button item-link popover-close"><i class="fas fa-edit"> <span data-translate="post-blog"></span></i></a></li>
+                        <li><a class="list-button item-link popover-close" href="#" data-translate="close"></a></li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+        {{/js_if}}
     </div>
-        </div>
 </template>
 <style>
     p {

--- a/www/pages/post-wire.html
+++ b/www/pages/post-wire.html
@@ -28,7 +28,7 @@
                     <div class="item-content item-input">
                         <div class="item-inner">
                             <div id="wire-body-label" class="item-title item-label" data-translate="attach-image"></div>
-                            <div id="image-display" class='item-media'>
+                            <div id="image-display" class='item-media' aria-hidden="true">
                                 <img id="picture-taken" src="" />
                             </div>
                             <div class="row">


### PR DESCRIPTION
Home Action Menu functional: closes #276 

Post-Wire: 
Aria-Hidden on the image div

Main Menu: 
Panel type changed to Panel-Cover due to screen reader issue. 
Focus Message for opening the Main Menu panel, which is set to focus on panel open.
Top of main menu is user information, entire thing is a onclick instead of just the avatar. Has aria-label for 'show-user' Inner elements are aria-hidden to reduce unnecessary elements for ScreenReaders.

MoreOptions: When more options popover is closed, will focus on the element that opened the MoreOptions popover. Allows keyboard/screen reader users to be at the same location in a content list after leaving the MoreOptions menu, when applicable.

Likes Popup: Likes popup focuses on open so screen reader/ keyboard users are at the correct location to view the popup.