### PR TITLE
In App Browser

### DIFF
--- a/www/js/GCT.js
+++ b/www/js/GCT.js
@@ -2990,22 +2990,22 @@ GCT = {
 
         } else if (obj.href.indexOf("https://gccollab.ca/") > -1) {
             console.log('loading collab page...');
-            window.open(obj.href, '_blank');
+            cordova.InAppBrowser.open(obj.href, '_blank');
 
         } else {
             // This shouldn't happen
             console.log('loading external page (Error)');
-            window.open(obj.href, '_system');
+            cordova.InAppBrowser.open(obj.href, '_system');
         }
         return false;
     },
     SiteLink: function (obj) {
         if (obj.href.indexOf("https://gccollab.ca/") > -1) {
             console.log('loading collab page...');
-            window.open(obj.href, '_blank');
+            cordova.InAppBrowser.open(obj.href, '_blank');
         } else {
             console.log('non-gccollab link through SiteLink function. (Error)');
-            window.open(obj.href, '_system');
+            cordova.InAppBrowser.open(obj.href, '_system');
         }
     },
     SetLinks: function (html) {

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -151,6 +151,11 @@ var mainView = app.views.create('.view-main', {
 $$(document).on('page:init', function (e) {
     GCTLang.TransPage();
 
+    $$(document).on('click', 'a.external', function (e) {
+        e.preventDefault();
+        cordova.InAppBrowser.open($(this).attr('href'), '_system');
+    });
+
     $$('#logoutBtn').on('click', function (e) {
         GCTUser.Logout();
         if (openid_enabled) {

--- a/www/js/routes.js
+++ b/www/js/routes.js
@@ -264,8 +264,9 @@ routes = [
         }
     },
     // Default route (404 page). MUST BE THE LAST
-    {
+    /*{
         path: '(.*)',
         url: './pages/404.html',
-    },
+    }, 
+    */
 ];


### PR DESCRIPTION
All pages have on click of a.external to open system browser.
All window.open calls changed to cordova.inappbrowser.open instead. Targets differentiate between system and inapp. (system vs blank)
Removed default 404 route as it triggers off of successful inapp links, and all links should be handled meaning 404 not needed.
closes #273 