### PR TITLE
Preloaders Added

### DIFF
--- a/www/js/GCT.js
+++ b/www/js/GCT.js
@@ -1248,7 +1248,7 @@ GCTEach = {
         $("#group-tags-" + obj.id).text(tags);
         $("[data-owner-" + obj.id +"]").data('owner', group.owner);
         $("[data-guid-" + obj.id +"]").data('guid', group.guid);
-        $("[data-type-" + obj.id +"]").data('type', group.type);
+        $("[data-type-" + obj.id + "]").data('type', group.type);
     },
     User: function (value, obj) {
         var profileData = value.result;
@@ -1446,6 +1446,7 @@ GCTEach = {
             $('#more-' + obj.id).hide();
         }
         obj.offset += obj.limit;
+        app.preloader.hide();
         var focusNow = document.getElementById('focus-' + obj.id);
         if (focusNow) { focusNow.focus(); }
     },
@@ -1522,6 +1523,7 @@ GCTEach = {
             $('#more-' + obj.id).hide();
         }
         obj.offset += obj.limit;
+        app.preloader.hide();
         var focusNow = document.getElementById('focus-' + obj.id);
         if (focusNow) { focusNow.focus(); }
     },
@@ -3245,6 +3247,7 @@ function prettyDate(date) {
 
 function errorConsole(jqXHR, textStatus, errorThrown) {
     console.log(jqXHR, textStatus, errorThrown);
+    app.preloader.hide();
 }
 
 var endOfContent = '<div class="card"><div class="card-content card-content-padding"><div class="card-content-inner"><div class="item-text">' + GCTLang.Trans("end-of-content") + '</div></div></div></div>';

--- a/www/js/GCT.js
+++ b/www/js/GCT.js
@@ -1942,7 +1942,7 @@ GCTrequests = {
         access = access || 1;
         status = status || 0;
 
-
+        app.preloader.show();
         app.request({
             method: 'POST',
             dataType: 'json',
@@ -1951,9 +1951,11 @@ GCTrequests = {
             timeout: 12000,
             success: function (data) {
                 successCallback(data);
+                app.preloader.hide();
             },
             error: function (jqXHR, textStatus, errorThrown) {
                 errorCallback(jqXHR, textStatus, errorThrown);
+                app.preloader.hide();
             }
         });
     },
@@ -1963,6 +1965,7 @@ GCTrequests = {
     },
     GetBlogEdit: function (post_guid, successCallback, errorCallback) {
         if (!post_guid) { return "cannot edit nothing"; } //force back? with message 
+        app.preloader.show();
         app.request({
             method: 'POST',
             dataType: 'json',
@@ -1971,9 +1974,11 @@ GCTrequests = {
             timeout: 12000,
             success: function (data) {
                 successCallback(data);
+                app.preloader.hide();
             },
             error: function (jqXHR, textStatus, errorThrown) {
                 errorCallback(jqXHR, textStatus, errorThrown);
+                app.preloader.hide();
             }
         });
     },
@@ -2281,7 +2286,7 @@ GCTrequests = {
         if (!(title.en && message.en) && !(title.fr && message.fr)) { issueCallback(GCTLang.Trans("require-same-lang")); return; }
         if (!container) { container = ''; }
         if (!topic) { topic = ''; }
-
+        app.preloader.show();
         app.request({
             method: 'POST',
             dataType: 'json',
@@ -2290,9 +2295,11 @@ GCTrequests = {
             timeout: 12000,
             success: function (data) {
                 successCallback(data);
+                app.preloader.hide();
             },
             error: function (jqXHR, textStatus, errorThrown) {
                 errorCallback(jqXHR, textStatus, errorThrown);
+                app.preloader.hide();
             }
         });
     },
@@ -2302,6 +2309,7 @@ GCTrequests = {
     },
     GetDiscussionEdit: function (post_guid, successCallback, errorCallback) {
         if (!post_guid) { return "cannot edit nothing"; } //force back? with message 
+        app.preloader.show();
         app.request({
             method: 'POST',
             dataType: 'json',
@@ -2310,9 +2318,11 @@ GCTrequests = {
             timeout: 12000,
             success: function (data) {
                 successCallback(data);
+                app.preloader.hide();
             },
             error: function (jqXHR, textStatus, errorThrown) {
                 errorCallback(jqXHR, textStatus, errorThrown);
+                app.preloader.hide();
             }
         });
     },

--- a/www/js/GCT.js
+++ b/www/js/GCT.js
@@ -1195,7 +1195,7 @@ GCTEach = {
     },
     GroupP: function (value, obj) {
         var group = value.result;
-
+        if (obj.loaded == true) { $(obj.appendMessage).appendTo('#content-' + obj.id); } else { obj.loaded = true; }
         var tags = (group.tags) ? ($.isArray(group.tags) ? (group.tags).join(", ") : group.tags) : GCTLang.Trans('no-tags');
         if (group.liked) {
             $(".like").addClass('liked');
@@ -1251,6 +1251,7 @@ GCTEach = {
         $("[data-type-" + obj.id + "]").data('type', group.type);
     },
     User: function (value, obj) {
+        if (obj.loaded == true) { $(obj.appendMessage).appendTo('#content-' + obj.id); } else { obj.loaded = true; }
         var profileData = value.result;
         if (typeof profileData == "string") {
             app.dialog.alert(GCTLang.Trans("couldnotfindprofile"));
@@ -1807,6 +1808,7 @@ GCTrequests = {
             timeout: 12000,
             success: function (data) {
                 GCTEach.User(data, tabObject);
+                app.preloader.hide();
             },
             error: function (jqXHR, textStatus, errorThrown) {
                 errorConsole(jqXHR, textStatus, errorThrown);
@@ -2188,6 +2190,7 @@ GCTrequests = {
             timeout: 12000,
             success: function (data) {
                 GCTEach.GroupP(data, tabObject);
+                app.preloader.hide();
             },
             error: function (jqXHR, textStatus, errorThrown) {
                 errorConsole(jqXHR, textStatus, errorThrown);

--- a/www/js/GCT.js
+++ b/www/js/GCT.js
@@ -2889,7 +2889,7 @@ GCTrequests = {
     },
     GetLikeUsers: function (obj) {
         var guid = $(obj).data("guid");
-
+        app.preloader.show();
         app.request({
             method: 'POST',
             dataType: 'json',
@@ -2918,10 +2918,11 @@ GCTrequests = {
                 $('#content-likes').html(content);
                 app.popup.open('.likes-popup');
                 $('#likes-menu').focus();
-
+                app.preloader.hide();
             },
             error: function (jqXHR, textStatus, errorThrown) {
                 console.log(jqXHR, textStatus, errorThrown);
+                app.preloader.hide();
             }
         });
     },

--- a/www/pages/entity-template.html
+++ b/www/pages/entity-template.html
@@ -71,7 +71,7 @@
                 var offset = 0;
                 console.log(guid + ' ' + type);
                 $("#comments-more-"+ guid).hide();
-                
+                app.preloader.show();
                 switch (type) {
                     case 'wire':
                         GCTrequests.GetWire(guid, 1, function (data) {
@@ -115,7 +115,8 @@
                                     image: img
                                 });
                             });
-                            $(content).hide().appendTo('#content-entity-'+guid).fadeIn(500);
+                            $(content).hide().appendTo('#content-entity-' + guid).fadeIn(500);
+                            app.preloader.hide();
                         });
                         break;
                     case 'blog':
@@ -153,8 +154,8 @@
                                     likes: likes
                                 });
                             });
-
                             $(content).hide().appendTo('#content-entity-' + guid).fadeIn(500);
+                            app.preloader.hide();
                         });
                         break;
                     case 'discussion':
@@ -194,6 +195,7 @@
 
                             });
                             $(content).hide().appendTo('#content-entity-' + guid).fadeIn(500);
+                            app.preloader.hide();
                         });
                         break;
                     case 'opportunity':
@@ -313,6 +315,7 @@
                             });
 
                             $(content).hide().appendTo('#content-entity-' + guid).fadeIn(500);
+                            app.preloader.hide();
                         });
                         break;
                     case 'bookmark':
@@ -349,6 +352,7 @@
                                 });
                             });
                             $(content).hide().appendTo('#content-entity-' + guid).fadeIn(500);
+                            app.preloader.hide();
                         });
                         break;
                     case 'event':
@@ -429,6 +433,7 @@
                                 });
                             });
                             $(content).hide().appendTo('#content-entity-' + guid).fadeIn(500);
+                            app.preloader.hide();
                         });
                         break;
                     case 'notification':
@@ -438,6 +443,7 @@
                             }
                         }, function (jqXHR, textStatus, errorThrown) {
                             console.log(jqXHR, textStatus, errorThrown);
+                            app.preloader.hide();
                         });
 
                         GCTrequests.GetNotification(guid, function (data) {
@@ -454,16 +460,19 @@
                             
                             content = GCT.SetLinks(content);
                             $(content).hide().appendTo('#content-entity-' + guid).fadeIn(500);
+                            app.preloader.hide();
 
                         }, function (jqXHR, textStatus, errorThrown) {
                             console.log(jqXHR, textStatus, errorThrown);
+                            app.preloader.hide();
                         });
                         break;
                     default:
                         break;
                 }
 
-                $$('#comments-view-'+guid).on('click', function (e) {
+                $$('#comments-view-' + guid).on('click', function (e) {
+                    app.preloader.show();
                     GCTrequests.GetComments(guid, limit, offset, function (data) {
                         $("#comments-view-" + guid).hide();
                         $("#comments-more-" + guid).show();
@@ -481,10 +490,12 @@
                             content += endOfContent;
                             $("#comments-more-" + guid).hide();
                         }
-                        $(content).hide().appendTo("#entity-comments-"+ guid).fadeIn(500);
+                        $(content).hide().appendTo("#entity-comments-" + guid).fadeIn(500);
+                        app.preloader.hide();
                     });
                 });
-                $$('#comments-more-'+guid).on('click', function (e) {
+                $$('#comments-more-' + guid).on('click', function (e) {
+                    app.preloader.show();
                     GCTrequests.GetComments(guid, limit, offset + limit, function (data) {
                         offset += limit;
                         var comments = data.result;
@@ -502,23 +513,28 @@
                             $("#comments-more-" + guid).hide();
                         }
                         $(content).hide().appendTo("#entity-comments-" + guid).fadeIn(500);
+                        app.preloader.hide();
                     });
                 });
                 $$('#comments-submit-' + guid).on('click', function (e) {
                     var comment = $$('#message-' + guid).val();
                     if (!(comment === '')) {
+                        app.preloader.show();
                         GCTrequests.SubmitComment(guid, comment, function (data) {
                             console.log("submited");
                             var result = data.result;
                             console.log(result);
+                            app.preloader.hide();
                         }, function (jqXHR, textStatus, errorThrown) {
                             console.log(jqXHR, textStatus, errorThrown);
+                            app.preloader.hide();
                         });
                     } else {
                         //empty message, dont use, give feedback
                     }
                 });
                 $$('#refresh-' + type + '-' + guid).on('click', function (e) {
+                    app.preloader.show();
                     mainView.router.refreshPage();
                 });
             },

--- a/www/pages/list-template.html
+++ b/www/pages/list-template.html
@@ -192,16 +192,19 @@
                 var tabs = this.tabs;
                 var filters = this.filters;
                 var page = this.page;
+                app.preloader.show();
                 tabs[0].request(tabs[0]); //load first tab, which is active tab
                 tabs.forEach(function (tab) {
                     //More Button
                     $$('#more-' + tab.id).on('click', function (e) {
+                        app.preloader.show();
                         $('#focus-' + tab.id).remove();
                         tab.request(tab);
                     });
                     //Tab Show
                     $$('#tab-' + tab.id).on('tab:show', function (e) {
                         if (!tab.loaded) {
+                            app.preloader.show();
                             tab.request(tab);
                         }
                     });
@@ -209,6 +212,7 @@
                 //Refresh Button - All
                 $$('#refresh-' + this.page).on('click', function (e) {
                     tabs.forEach(function (tab) {
+                        app.preloader.show();
                         GCTtabs.TabReset(tab);
                     });
                 });
@@ -216,6 +220,7 @@
                     $$('#save-filters-' + this.page).on('click', function (e) {
                         var temp = JSON.stringify(app.form.convertToData('#filter-form-' + page));
                         tabs.forEach(function (tab) {
+                            app.preloader.show();
                             tab.filters = temp;
                             console.log(tab.filters);
                             GCTtabs.TabReset(tab);
@@ -224,6 +229,7 @@
                     $$('#clear-filters-' + this.page).on('click', function (e) {
                         document.getElementById('filter-form-' + page).reset();
                         tabs.forEach(function (tab) {
+                            app.preloader.show();
                             tab.filters = '';
                             console.log(tab.filters);
                             GCTtabs.TabReset(tab);

--- a/www/pages/profile-template.html
+++ b/www/pages/profile-template.html
@@ -140,16 +140,19 @@
             pageInit: function (e, page) {
                 var guid = this.guid;
                 var tabs = this.tabs;
+                app.preloader.show();
                 tabs[0].request(tabs[0], guid); //load first tab, which is active tab
                 tabs.forEach(function (tab) {
                     //More Button
                     $$('#more-' + tab.id).on('click', function (e) {
+                        app.preloader.show();
                         $('#focus-' + tab.id).remove();
                         tab.request(tab, guid);
                     });
                     //Tab Show
                     $$('#tab-' + tab.id).on('tab:show', function (e) {
                         if (!tab.loaded) {
+                            app.preloader.show();
                             tab.request(tab, guid);
                         }
                     });
@@ -157,6 +160,7 @@
                 //Refresh Button - All
                 $$('#refresh-profile-' + guid).on('click', function (e) {
                     tabs.forEach(function (tab) {
+                        app.preloader.show();
                         GCTtabs.TabReset(tab, guid);
                     });
                 });


### PR DESCRIPTION
Added preloader show/hide for content that hits a api request. Original blanket way with ajax events (ajaxStart/Error/Success) no longer works due to the way requests work in F7v2.  
Template/Tab/Comments aspects are handled on the ContentSuccess and Template Functions.
Post/Edit Blog/Discussion, and likes page, added within their requests.
Profile Template on the template functions and the Each functions.

Closes #290 