### PR TITLE
Group/Home Action Popover, and Filters Popup: Focus on Open/Close & Minor Fixes

### DIFF
--- a/www/js/GCT.js
+++ b/www/js/GCT.js
@@ -737,7 +737,7 @@ GCTEach = {
                 case "etherpad": description = GCTLang.Trans("doc-create"); type = "gccollab_doc"; break;
                 case "event_calendar": description = GCTLang.Trans("event-create"); type = "gccollab_event"; break;
                 case "bookmarks": description = GCTLang.Trans("bookmark-create"); type = "gccollab_bookmark"; break;
-                case "page_top": description = GCTLang.Trans("page-create"); type = "gccollab_page"; break;
+                case "page": case "page_top": description = GCTLang.Trans("page-create"); type = "gccollab_page"; break;
                 default: description = "NEED TO HANDLE CREATE";
             }
         } else { //OTHER

--- a/www/js/GCT.js
+++ b/www/js/GCT.js
@@ -44,7 +44,7 @@
         return action;
     },
     txtFilterButton: function (ref) {
-        var filterButton = '<a href="#" data-popup=".filters-' + ref + '" class="popup-open link icon-only" data-translate-target="aria-label" data-translate="filter-options"><i class="fas fa-search fa-2x"></i></a>';
+        var filterButton = '<a id="filters-button-'+ref+'" href="#" data-popup=".filters-' + ref + '" class="popup-open link icon-only" data-translate-target="aria-label" data-translate="filter-options"><i class="fas fa-search fa-2x"></i></a>';
         return filterButton;
     },
     txtTabHeader: function (ref, id) {

--- a/www/js/Lang.js
+++ b/www/js/Lang.js
@@ -175,6 +175,8 @@
     "view-post": "View Post",
     "view-group": "View Group",
 
+    "create-links": "Create Content Links",
+    "create-group-content": "Create Group Content",
     "create-wire": "Create a new Wire post",
     "new-blog-post": "New Blog Post",
     "new-wire-post": "New Wire Post",
@@ -579,6 +581,8 @@ French = {
     "view-post": "Voir l'article",
     "view-group": "View le Groupe",
 
+    "create-links": "Créer des Liens de Contenu",
+    "create-group-content": "Créer un Contenu de Groupe",
     "create-wire": "Créer un nouveau fil",
     "new-blog-post": "Ajouter un blogue",
     "new-wire-post": "Ajouter un fil",

--- a/www/pages/list-template.html
+++ b/www/pages/list-template.html
@@ -63,7 +63,7 @@
                     <div class="navbar">
                         <div class="navbar-inner">
                             <div class="left"><a href="#" class="link popup-close" data-translate-target="aria-label" data-translate="close"><i class="far fa-times-circle"></i></a></div>
-                            <div class="title" data-translate="filter-{{page}}"></div>
+                            <div id="{{page}}-filters-title" class="title" data-translate="filter-{{page}}" tabindex="0"></div>
                         </div>
                     </div>
                     <div class="page-content">
@@ -235,6 +235,14 @@
                             console.log(tab.filters);
                             GCTtabs.TabReset(tab);
                         });
+                    });
+                    $$('.filters-' + page).on('popup:open', function () {
+                        var focusNow = document.getElementById(page + '-filters-title');
+                        if (focusNow) { focusNow.focus(); }
+                    });
+                    $$('.filters-' + page).on('popup:close', function () {
+                        var focusNow = document.getElementById('filters-button-' + page);
+                        if (focusNow) { focusNow.focus(); }
                     });
                 }
                 if (page === 'home') {

--- a/www/pages/list-template.html
+++ b/www/pages/list-template.html
@@ -45,6 +45,7 @@
         {{#js_if "this.page === 'home'"}}
         <div class="popover popover-actions-{{page}}">
             <div class="popover-inner">
+                <div id="{{page}}-actions-title" class="block-title" tabindex="0" data-translate="create-links"></div>
                 <div class="list">
                     <ul id="popover-actions-{{page}}">
                         <li><a href="#" onclick="GCTrequests.PostWirePost();" class="list-button item-link popover-close"><i class="fas fa-rss"> <span data-translate="create-wire"></span></i></a></li>
@@ -234,6 +235,16 @@
                             console.log(tab.filters);
                             GCTtabs.TabReset(tab);
                         });
+                    });
+                }
+                if (page === 'home') {
+                    $$('.popover-actions-home').on('popover:opened', function (e, popover) {
+                        var focusTitle = document.getElementById('home-actions-title');
+                        if (focusTitle) { focusTitle.focus(); }
+                    });
+                    $$('.popover-actions-home').on('popover:close', function () {
+                        var focusNow = document.getElementById(page + '-actions');
+                        if (focusNow) { focusNow.focus(); }
                     });
                 }
             },

--- a/www/pages/profile-template.html
+++ b/www/pages/profile-template.html
@@ -72,7 +72,6 @@
                         <div class="item-inner">
                             <div class="row">
                                 <div class="col-85 item-title" id="group-title-{{this.id}}"></div>
-                                <a href="#" class="col-15 link pull-right more-options" data-owner-{{this.id}}="" data-guid-{{this.id}}="" data-type-{{this.id}}="gccollab_group" onclick="GCTUser.MoreOptions(this);"><i class="fa fa-caret-down"></i></a>
                             </div>
                             <div class="item-subtitle" id="group-owner-click-{{this.id}}"><span data-translate="owner">Owner</span>: <span id="group-owner-{{this.id}}"></span></div>
                         </div>

--- a/www/pages/profile-template.html
+++ b/www/pages/profile-template.html
@@ -125,6 +125,7 @@
         <div class="popover popover-actions-{{guid}}">
             <div class="popover-inner">
                 <div class="list">
+                    <div id="{{guid}}-actions-title" class="block-title" tabindex="0" data-translate="create-group-content"></div>
                     <ul id="popover-actions-{{guid}}">
                         <li><a class="list-button item-link popover-close" href="#" data-translate="close">close</a></li>
                     </ul>
@@ -169,6 +170,14 @@
                 });
                 $$('.popover-links-' + guid).on('popover:open', function () {
                     var focusNow = document.getElementById('focus-links-popover-' + guid);
+                    if (focusNow) { focusNow.focus(); }
+                });
+                $$('.popover-actions-' + guid).on('popover:open', function () {
+                    var focusNow = document.getElementById(guid + '-actions-title');
+                    if (focusNow) { focusNow.focus(); }
+                });
+                $$('.popover-actions-' + guid).on('popover:close', function () {
+                    var focusNow = document.getElementById('actions-' + guid);
                     if (focusNow) { focusNow.focus(); }
                 });
             },


### PR DESCRIPTION
Additional Newsfeed handle for Page creation. #166

Removed Group Page MoreOptions Caret. closes #306

Group/Home Focus on Open/Close of Actions Popover. With translated text for the new titles added as focus target. closes #303 

Filters (list-template) focus on Open/Close of Filter Popup. closes #313 
