### PR TITLE
Subnav Context

### DIFF
--- a/www/js/Lang.js
+++ b/www/js/Lang.js
@@ -293,6 +293,7 @@
     "reason-decline-opportunity":"Reason to decline the offer to participate in this opportunity",
     "message-creator-opportunity": "Message to opportunity creator",
 
+    "tab": "tab",
     "content-loaded": "New content appended to page.",
     "more-options-opened": "More Options Menu Opened.",
     "more-tab-menu-opened": "More Tabs List",
@@ -699,6 +700,7 @@ French = {
     "reason-decline-opportunity":"Raison pour le retrait de votre participation à cette possibilité",
     "message-creator-opportunity": "Message au gestionnaire",
 
+    "tab": "onglet",
     "content-loaded": "Nouveau contenu ajouté à la page.",
     "more-options-opened": "Plus d'options menu ouvert.",
     "more-tab-menu-opened": "Plus de liste d'onglets",

--- a/www/pages/list-template.html
+++ b/www/pages/list-template.html
@@ -10,7 +10,7 @@
                     <div class="subnavbar-inner">
                         <div class="segmented">
                             {{#each tabs}}
-                            <a href="#tab-{{this.id}}" class="button {{#if @first}}tab-link-active{{/if}} tab-link" data-translate="{{this.name}}"></a>
+                            <a href="#tab-{{this.id}}" id="tab-link-{{this.id}}" class="button {{#if @first}}tab-link-active{{/if}} tab-link" data-translate="{{this.name}}"></a>
                             {{/each}}
                         </div>
                     </div>
@@ -209,6 +209,7 @@
                             tab.request(tab);
                         }
                     });
+                    $$('#tab-link-' + tab.id).attr('aria-label', GCTLang.Trans(tab.name) + ' ' + GCTLang.Trans("tab"));
                 });
                 //Refresh Button - All
                 $$('#refresh-' + this.page).on('click', function (e) {

--- a/www/pages/profile-template.html
+++ b/www/pages/profile-template.html
@@ -9,12 +9,12 @@
                     <div class="subnavbar-inner">
                         <div class="segmented">
                             {{#js_if "this.tabs[0].type == 'group'"}}
-                            <a href="#tab-profile-{{guid}}-profile" class="button tab-link tab-link-active" data-translate="profile">Profile</a>
-                            <a href="#tab-profile-{{guid}}-members" class="button tab-link" data-translate="members">members</a>
+                            <a href="#tab-profile-{{guid}}-profile" id="tab-link-{{this.tabs[0].id}}" class="button tab-link tab-link-active" data-translate="profile">Profile</a>
+                            <a href="#tab-profile-{{guid}}-members" id="tab-link-{{this.tabs[1].id}}" class="button tab-link" data-translate="members">members</a>
                             {{/js_if}}
                             {{#js_if "this.tabs[0].type == 'user'"}}
-                            <a href="#tab-profile-{{guid}}-profile" class="button tab-link tab-link-active" data-translate="profile">Profile</a>
-                            <a href="#tab-profile-{{guid}}-groups" class="button tab-link" data-translate="groups">Groups</a>
+                            <a href="#tab-profile-{{guid}}-profile" id="tab-link-{{this.tabs[0].id}}" class="button tab-link tab-link-active" data-translate="profile">Profile</a>
+                            <a href="#tab-profile-{{guid}}-groups" id="tab-link-{{this.tabs[1].id}}" class="button tab-link" data-translate="groups">Groups</a>
                             {{/js_if}}
                             <a id="profile-menu-{{guid}}" class="button popover-open" href="#" data-popover=".popover-links-{{guid}}" data-translate="more">More</a>
                         </div>
@@ -142,6 +142,8 @@
                 var tabs = this.tabs;
                 app.preloader.show();
                 tabs[0].request(tabs[0], guid); //load first tab, which is active tab
+                $$('#tab-link-' + tabs[0].id).attr('aria-label', GCTLang.Trans(tabs[0].name) + ' ' + GCTLang.Trans("tab"));
+                $$('#tab-link-' + tabs[1].id).attr('aria-label', GCTLang.Trans(tabs[1].name) + ' ' + GCTLang.Trans("tab"));
                 tabs.forEach(function (tab) {
                     //More Button
                     $$('#more-' + tab.id).on('click', function (e) {


### PR DESCRIPTION
List-Template and Profile-Template, the subnavbar which holds the different tab-links now have context for Screenreader. Each tab-link has an aria-label, so instead of just the name of the tab, with no context, it's the name of the tab + the word tab. "Newsfeed Tab" Gives context for non-visual users utilizing SR. closes #302 