### PR TITLE
Images For Wire Replies

### DIFF
--- a/www/js/GCT.js
+++ b/www/js/GCT.js
@@ -2176,7 +2176,7 @@ GCTrequests = {
             dataType: 'json',
             url: GCT.GCcollabURL,
             data: { method: "post.wire", user: GCTUser.Email(), message: message, image: imageURI, api_key: api_key_gccollab, lang: GCTLang.Lang() },
-            timeout: 12000,
+            timeout: 45000,
             success: function (data) {
                 app.preloader.hide();
                 successCallback(data);
@@ -2184,6 +2184,7 @@ GCTrequests = {
             error: function (jqXHR, textStatus, errorThrown) {
                 app.preloader.hide();
                 errorCallback(jqXHR, textStatus, errorThrown);
+                alert(errorThrown);
             }
         });
     },
@@ -2199,7 +2200,7 @@ GCTrequests = {
             dataType: 'json',
             url: GCT.GCcollabURL,
             data: { method: "reply.wire", user: GCTUser.Email(), guid: guid, message: message, image: imageURI, api_key: api_key_gccollab, lang: GCTLang.Lang() },
-            timeout: 12000,
+            timeout: 45000,
             success: function (data) {
                 app.preloader.hide();
                 successCallback(data);
@@ -2207,6 +2208,7 @@ GCTrequests = {
             error: function (jqXHR, textStatus, errorThrown) {
                 app.preloader.hide();
                 errorCallback(jqXHR, textStatus, errorThrown);
+                alert(errorThrown);
             }
         });
     },

--- a/www/js/GCT.js
+++ b/www/js/GCT.js
@@ -2192,17 +2192,20 @@ GCTrequests = {
         var type = $(obj).data("type");
         mainView.router.navigate('/wire/reply/' + guid + '/' + type + '/');
     },
-    ReplyWire: function (guid, message, successCallback, errorCallback) {
+    ReplyWire: function (guid, message, imageURI, successCallback, errorCallback) {
+        app.preloader.show();
         app.request({
             method: 'POST',
             dataType: 'json',
             url: GCT.GCcollabURL,
-            data: { method: "reply.wire", user: GCTUser.Email(), guid: guid, message: message, api_key: api_key_gccollab, lang: GCTLang.Lang() },
+            data: { method: "reply.wire", user: GCTUser.Email(), guid: guid, message: message, image: imageURI, api_key: api_key_gccollab, lang: GCTLang.Lang() },
             timeout: 12000,
             success: function (data) {
+                app.preloader.hide();
                 successCallback(data);
             },
             error: function (jqXHR, textStatus, errorThrown) {
+                app.preloader.hide();
                 errorCallback(jqXHR, textStatus, errorThrown);
             }
         });

--- a/www/js/gccollab.js
+++ b/www/js/gccollab.js
@@ -237,7 +237,7 @@ $$(document).on('page:init', '.page[data-name="post-wire"]', function (e) {
             }, function onFail(message) {
                 // myApp.alert('Failed because: ' + message);
             }, {
-                    quality: 95,
+                    quality: 75,
                     sourceType: Camera.PictureSourceType.CAMERA,
                     destinationType: Camera.DestinationType.DATA_URL,
                     encodingType: Camera.EncodingType.JPEG,

--- a/www/pages/wire-reply.html
+++ b/www/pages/wire-reply.html
@@ -84,7 +84,7 @@
                         }, function onFail(message) {
                             // myApp.alert('Failed because: ' + message);
                         }, {
-                                quality: 95,
+                                quality: 75,
                                 sourceType: Camera.PictureSourceType.CAMERA,
                                 destinationType: Camera.DestinationType.DATA_URL,
                                 encodingType: Camera.EncodingType.JPEG,

--- a/www/pages/wire-reply.html
+++ b/www/pages/wire-reply.html
@@ -28,7 +28,7 @@
                             </div>
                         </div>
                     </li>
-                   <!-- <li>
+                   <li>
                         <div class="item-content item-input">
                             <div class="item-inner">
                                 <div id="wire-body-label" class="item-title item-label" data-translate="attach-image"></div>
@@ -41,7 +41,7 @@
                                 </div>
                             </div>
                         </div>
-                    </li> -->
+                    </li>
                     <li>
                         <div class="item-content item-input">
                             <div class="item-inner">
@@ -64,7 +64,7 @@
                 $$('#submit-post-wire').on('click', function (e) {
                     var message = $("#post-wire-textarea").val();
                     if (message) {
-                        GCTrequests.ReplyWire(guid, message, function (data) {
+                        GCTrequests.ReplyWire(guid, message, imageURI, function (data) {
                             console.log(data);
                             app.dialog.alert(data.result, '', function () {
                                 mainView.router.navigate('/list-template/wires/');


### PR DESCRIPTION
Send data64 image with request for wire.reply.
Increased timeout to compensate for slow connection combo-ed with uploading an image. 12s->45s.
Decreased quality slightly to lower data required for wire image uploading. 95->75.
Alert for errorThrown on failed wire post/reply, mostly for feedback on the timeout being the failure. 
closes #286 

related api PR: https://github.com/gctools-outilsgc/gcconnex/pull/1884