### PR TITLE
Colleague action feedback

### DIFF
--- a/www/js/GCT.js
+++ b/www/js/GCT.js
@@ -24,6 +24,9 @@
     txtFocusMessage: function (id) {
         return '<span id="focus-' + id + '" class="reader-text" tabindex="0">' + GCTLang.Trans('content-loaded') + '</span>';
     },
+    txtResultFeedback: function (id, message) {
+        return "<span id='focus-" + id + "' tabindex='0'>" + message + "</span>";
+    },
     txtAction: function (ref) {
         var action = '';
         switch (ref) {
@@ -1788,7 +1791,10 @@ GCTUser = {
             timeout: 12000,
             success: function (data) {
                 console.log(data);
-                if (data.result) { $$('#request-actions-' + guid).html(data.result); }
+                if (data.result) {
+                    $$('#request-actions-' + guid).html(GCTtxt.txtResultFeedback(guid, data.result));
+                    $('#focus-' + guid).focus();
+                }
             },
             error: function (jqXHR, textStatus, errorThrown) {
                 console.log(jqXHR, textStatus, errorThrown);
@@ -1811,7 +1817,10 @@ GCTUser = {
             timeout: 12000,
             success: function (data) {
                 console.log(data);
-                if (data.result) { $$('#request-actions-' + guid).html(data.result); }
+                if (data.result) {
+                    $$('#request-actions-' + guid).html(GCTtxt.txtResultFeedback(guid, data.result));
+                    $('#focus-' + guid).focus();
+                }
             },
             error: function (jqXHR, textStatus, errorThrown) {
                 console.log(jqXHR, textStatus, errorThrown);

--- a/www/js/GCT.js
+++ b/www/js/GCT.js
@@ -279,7 +279,7 @@
         return content;
     },
     txtMember: function (object) {
-        var content = "<div class='hold-all-card'>"
+        var content = "<div class='hold-all-card' id='request-" + object.guid + "'>"
             + "<div id='label-" + object.guid + "' class='reader-text' data-guid='" + object.guid + "' data-type='gccollab_user' onclick='ShowProfile(" + object.guid + ");'>" + object.label + "</div>"
             + "<div class='item-link item-content close-popup close-panel' data-guid='" + object.guid + "' data-type='gccollab_user' onclick='ShowProfile(" + object.guid + ");' aria-hidden='true'>"
             + "<div class='item-inner'>"
@@ -1470,7 +1470,7 @@ GCTEach = {
         return content;
     },
     ColleagueRequest: function (value, obj) {
-        var description = '<div class="row"><div class="col-50"><span class="button button-fill button-raised" data-guid="' + value.user_id + '" onclick="GCTUser.ApproveColleague(this);">' + GCTLang.Trans("accept") + '</span></div><span class="col-50"><div class="button button-fill button-raised" data-guid="' + value.user_id + '" onclick="GCTUser.DeclineColleague(this);">' + GCTLang.Trans("decline") + '</span></div></div>';
+        var description = '<div class="row" id="request-actions-' + value.user_id+'"><div class="col-50"><span class="button button-fill button-raised" data-guid="' + value.user_id + '" onclick="GCTUser.ApproveColleague(this);">' + GCTLang.Trans("accept") + '</span></div><span class="col-50"><div class="button button-fill button-raised" data-guid="' + value.user_id + '" onclick="GCTUser.DeclineColleague(this);">' + GCTLang.Trans("decline") + '</span></div></div>';
 
         var content = GCTtxt.txtMember({
             guid: value.user_id,
@@ -1788,6 +1788,7 @@ GCTUser = {
             timeout: 12000,
             success: function (data) {
                 console.log(data);
+                if (data.result) { $$('#request-actions-' + guid).html(data.result); }
             },
             error: function (jqXHR, textStatus, errorThrown) {
                 console.log(jqXHR, textStatus, errorThrown);
@@ -1810,6 +1811,7 @@ GCTUser = {
             timeout: 12000,
             success: function (data) {
                 console.log(data);
+                if (data.result) { $$('#request-actions-' + guid).html(data.result); }
             },
             error: function (jqXHR, textStatus, errorThrown) {
                 console.log(jqXHR, textStatus, errorThrown);

--- a/www/js/GCT.js
+++ b/www/js/GCT.js
@@ -1752,9 +1752,15 @@ GCTUser = {
             timeout: 12000,
             success: function (data) {
                 console.log(data);
+                if (data.result) {
+                    var result = toast(obj, "friends:add:successful");
+                } else if (data.message) {
+                    var result = toast(obj, "friends:add:pending");
+                }
             },
             error: function (jqXHR, textStatus, errorThrown) {
                 console.log(jqXHR, textStatus, errorThrown);
+                var result = toast(obj, "friends:add:error");
             }
         });
     },
@@ -1769,9 +1775,11 @@ GCTUser = {
             timeout: 12000,
             success: function (data) {
                 console.log(data);
+                var result = toast(obj, "friends:removal:successful");
             },
             error: function (jqXHR, textStatus, errorThrown) {
                 console.log(jqXHR, textStatus, errorThrown);
+                alert(errorThrown);
             }
         });
     },
@@ -3516,3 +3524,13 @@ function errorConsole(jqXHR, textStatus, errorThrown) {
 
 var endOfContent = '<div class="card"><div class="card-content card-content-padding"><div class="card-content-inner"><div class="item-text">' + GCTLang.Trans("end-of-content") + '</div></div></div></div>';
 
+function toast(obj, message) {
+    var result = app.toast.create({
+        text: GCTLang.Trans(message),
+        position: 'center',
+        closeTimeout: 2000,
+    });
+    result.open();
+    $$(obj).remove();
+    return result;
+}

--- a/www/js/GCT.js
+++ b/www/js/GCT.js
@@ -1773,6 +1773,11 @@ GCTUser = {
         });
     },
     ApproveColleague: function (obj) {
+        //Stops outer events (onclick to the whole post) from triggering if this was reached from a child to it
+        if (!e) var e = window.event;
+        e.cancelBubble = true;
+        if (e.stopPropagation) e.stopPropagation();
+
         var guid = $(obj).data("guid");
 
         app.request({
@@ -1783,7 +1788,6 @@ GCTUser = {
             timeout: 12000,
             success: function (data) {
                 console.log(data);
-                ShowColleagueRequests();
             },
             error: function (jqXHR, textStatus, errorThrown) {
                 console.log(jqXHR, textStatus, errorThrown);
@@ -1791,6 +1795,11 @@ GCTUser = {
         });
     },
     DeclineColleague: function (obj) {
+        //Stops outer events (onclick to the whole post) from triggering if this was reached from a child to it
+        if (!e) var e = window.event;
+        e.cancelBubble = true;
+        if (e.stopPropagation) e.stopPropagation();
+
         var guid = $(obj).data("guid");
 
         app.request({
@@ -1801,7 +1810,6 @@ GCTUser = {
             timeout: 12000,
             success: function (data) {
                 console.log(data);
-                ShowColleagueRequests();
             },
             error: function (jqXHR, textStatus, errorThrown) {
                 console.log(jqXHR, textStatus, errorThrown);

--- a/www/js/Lang.js
+++ b/www/js/Lang.js
@@ -428,7 +428,12 @@
     "event-contact": "Contact",
     "contact_email": "E-mail address",
     "contact_phone": "Phone number",
-    "event-language": "Event Language"
+    "event-language": "Event Language",
+
+    "friends:add:successful": "Successfully added as a colleague.",
+    "friends:add:pending": "Requested to be colleagues.",
+    "friends:add:error": "We couldn't add as a colleague.",
+    "friends:removal:successful": "Successfully removed from your colleagues.",
 }
 
 French = {
@@ -864,5 +869,10 @@ French = {
     "event-contact": "Personne ressource",
     "contact_email": "Adresse courriel",
     "contact_phone": "Numéro de téléphone",
-    "event-language": "Langue de l'événement"
+    "event-language": "Langue de l'événement",
+
+    "friends:add:successful": "Ajouté à vos collègues.",
+    "friends:add:pending": "Demandé d'être des collègues.",
+    "friends:add:error": "N'a pas pu être ajouté(e) à vos collègues",
+    "friends:removal:successful": "Retiré de vos collègues.",
 }


### PR DESCRIPTION
Stop Propagation on Approve/Decline on Colleague Request page. Stops the onclick ShowProfile.
Colleague Request Page's Approve/Decline on success will remove the buttons, and replace it with the result message. Then focus onto that message so SR users will know the feedback.
Function txtResultFeedback used to create the message.

User Profile's utilize toast component to provide the feedback. Removes button as well.

closes #256 