### PR TITLE
Component Focus Traps | Toast/SR-text Notifications/Feedback

### DIFF
--- a/www/css/collab.css
+++ b/www/css/collab.css
@@ -76,6 +76,10 @@ ul > li{padding-bottom:10px}
     border-radius: 8px;
 }
 /* Text Containers */
+.notification-success {
+    background-color: #278400;
+    color: white;
+}
 .more_text {
     max-height: 60px !important;
     -webkit-line-clamp: 3 !important;

--- a/www/css/collab.css
+++ b/www/css/collab.css
@@ -76,10 +76,6 @@ ul > li{padding-bottom:10px}
     border-radius: 8px;
 }
 /* Text Containers */
-.notification-success {
-    background-color: #278400;
-    color: white;
-}
 .more_text {
     max-height: 60px !important;
     -webkit-line-clamp: 3 !important;
@@ -109,6 +105,24 @@ ul > li{padding-bottom:10px}
     -moz-hyphens: auto;
     -webkit-hyphens: auto;
     hyphens: auto;
+}
+/* notifcation & toast notifcations */
+.notification-success .toast-content,
+.notification-success {
+    background-color: #278400;
+    color: #FAFAFA;
+}
+
+.notification-info .toast-content,
+.notification-info {
+    background-color: #245269;
+    color: #FAFAFA;
+}
+
+.notification-error .toast-content,
+.notification-error {
+    background-color: #D3080C;
+    color: #FAFAFA;
 }
 /* Basic Padding */
 .vertical-padding {

--- a/www/js/GCT.js
+++ b/www/js/GCT.js
@@ -3561,7 +3561,7 @@ function cToast(message, type) {
     var toast = app.toast.create({
         text: message,
         position: 'center',
-        closeTimeout: 3000,
+        closeTimeout: 4000,
         cssClass: 'notification-' + notificationType
     });
     return toast;
@@ -3593,7 +3593,7 @@ function srToast(message, sr, obj, type) {
     var toast = app.toast.create({
         text: message,
         position: 'center',
-        closeTimeout: 3000,
+        closeTimeout: 4000,
         cssClass: 'notification-' + notificationType,
         on: {
             open: function (popover) {

--- a/www/js/GCT.js
+++ b/www/js/GCT.js
@@ -1280,8 +1280,12 @@ GCTEach = {
         }
         if (group.member) {
             $("#leave-group-" + obj.id).show();
+            $("#join-group-" + obj.id).hide();
+            $$("#leave-group-" + obj.id).removeClass('disabled');
         } else {
             $("#join-group-" + obj.id).show();
+            $("#leave-group-" + obj.id).hide();
+            $$("#join-group-" + obj.id).removeClass('disabled');
         }
         access = group.access;
         $("#group-description-" + obj.id).html(group.description);
@@ -1809,7 +1813,7 @@ GCTUser = {
             },
             error: function (jqXHR, textStatus, errorThrown) {
                 console.log(jqXHR, textStatus, errorThrown);
-                alert(errorThrown);
+                notificationTempToastSR(obj, errorThrown, 'error');
             }
         });
     },
@@ -1895,11 +1899,12 @@ GCTUser = {
             data: { method: "group.join", user: GCTUser.Email(), guid: guid, api_key: api_key_gccollab, lang: GCTLang.Lang() },
             timeout: 12000,
             success: function (data) {
-                $("#join-group-profile-"+guid+"-profile").hide();
-                $("#leave-group-profile-" + guid + "-profile").show();
+                var response = data.result || '';
+                notificationToastSR(obj, response , 'disable-parent', 'success');
             },
             error: function (jqXHR, textStatus, errorThrown) {
                 console.log(jqXHR, textStatus, errorThrown);
+                notificationTempToastSR(obj, errorThrown, 'error');
             }
         });
     },
@@ -1913,11 +1918,12 @@ GCTUser = {
             data: { method: "group.leave", user: GCTUser.Email(), guid: guid, api_key: api_key_gccollab, lang: GCTLang.Lang() },
             timeout: 12000,
             success: function (data) {
-                $("#leave-group-profile-" + guid + "-profile").hide();
-                $("#join-group-profile-" + guid + "-profile").show();
+                var response = data.result || '';
+                notificationToastSR(obj, response, 'disable-parent', 'success');
             },
             error: function (jqXHR, textStatus, errorThrown) {
                 console.log(jqXHR, textStatus, errorThrown);
+                notificationTempToastSR(obj, errorThrown, 'error');
             }
         });
     },
@@ -3557,7 +3563,6 @@ function errorConsole(jqXHR, textStatus, errorThrown) {
 }
 
 var endOfContent = '<div class="notification-info item-content"><span class="feedback-text" tabindex="0">' + GCTLang.Trans("end-of-content") + '</span></div>';
-// "<span id='focus-" + id + "' class='feedback-text' tabindex='0'>" + message + "</span>";
 
  // returns basic center toast
 function cToast(message, type) {

--- a/www/js/GCT.js
+++ b/www/js/GCT.js
@@ -1780,14 +1780,14 @@ GCTUser = {
             success: function (data) {
                 console.log(data);
                 if (data.result) {
-                    notificationToastSR(obj, GCTLang.Trans('friends:add:successful'), 'disable-parent');
+                    notificationToastSR(obj, GCTLang.Trans('friends:add:successful'), 'disable-parent', 'success');
                 } else if (data.message) {
-                    notificationToastSR(obj, GCTLang.Trans('friends:add:pending'), 'disable-parent');
+                    notificationToastSR(obj, GCTLang.Trans('friends:add:pending'), 'disable-parent', 'success');
                 }
             },
             error: function (jqXHR, textStatus, errorThrown) {
                 console.log(jqXHR, textStatus, errorThrown);
-                notificationTempToastSR(obj, GCTLang.Trans('friends:add:error'));
+                notificationTempToastSR(obj, GCTLang.Trans('friends:add:error'), 'error');
             }
         });
     },
@@ -1801,7 +1801,7 @@ GCTUser = {
             data: { method: "remove.colleague", user: GCTUser.Email(), profileemail: guid, api_key: api_key_gccollab, lang: GCTLang.Lang() },
             timeout: 12000,
             success: function (data) {
-                notificationToastSR(obj, GCTLang.Trans('friends:removal:successful'), 'disable-parent');
+                notificationToastSR(obj, GCTLang.Trans('friends:removal:successful'), 'disable-parent', 'success');
             },
             error: function (jqXHR, textStatus, errorThrown) {
                 console.log(jqXHR, textStatus, errorThrown);
@@ -1831,7 +1831,7 @@ GCTUser = {
             },
             error: function (jqXHR, textStatus, errorThrown) {
                 console.log(jqXHR, textStatus, errorThrown);
-                notificationTempToastSR(obj, errorThrown);
+                notificationTempToastSR(obj, errorThrown, 'error');
             }
         });
     },
@@ -3552,20 +3552,23 @@ function errorConsole(jqXHR, textStatus, errorThrown) {
     app.preloader.hide();
 }
 
-var endOfContent = '<div class="card"><div class="card-content card-content-padding"><div class="card-content-inner"><div class="item-text">' + GCTLang.Trans("end-of-content") + '</div></div></div></div>';
+var endOfContent = '<div class="card notification-info item-content"><span class="feedback-text" tabindex="0">' + GCTLang.Trans("end-of-content") + '</span></div>';
+// "<span id='focus-" + id + "' class='feedback-text' tabindex='0'>" + message + "</span>";
 
  // returns basic center toast
-function cToast(message) {
+function cToast(message, type) {
+    var notificationType = type || 'info'; //defaults to info
     var toast = app.toast.create({
         text: message,
         position: 'center',
         closeTimeout: 3000,
+        cssClass: 'notification-' + notificationType
     });
     return toast;
 }
  // creates center toast(cToast), extra/sr-text based on input, and focuses toast-sr text.
-function notificationToastSR(obj, message, extra) {
-    var result = cToast(message);
+function notificationToastSR(obj, message, extra, type) {
+    var result = cToast(message, type);
     result.open();
     $$('#toast-sr').remove(); //remove any old toast message
     if (extra === 'disable-parent') {
@@ -3578,18 +3581,20 @@ function notificationToastSR(obj, message, extra) {
 }
 
  // Append SR to obj. Create srToast, which has lifecycle hooks to set focus to SR object while open, then back to original object.
-function notificationTempToastSR(obj, message) {
+function notificationTempToastSR(obj, message, type) {
     $$('#toast-sr').remove(); //remove any old toast message
     $$('<span id="toast-sr" class="reader-text" tabindex="0">' + message + '</span>').appendTo(obj);
-    var toast = srToast(message, '#toast-sr', obj);
+    var toast = srToast(message, '#toast-sr', obj, type);
     toast.open();
 }
 // Toast with lifecycle hooks to set focus to SR object while open, then back to original object.
-function srToast(message, sr, obj) {
+function srToast(message, sr, obj, type) {
+    var notificationType = type || 'info'; //defaults to info
     var toast = app.toast.create({
         text: message,
         position: 'center',
         closeTimeout: 3000,
+        cssClass: 'notification-' + notificationType,
         on: {
             open: function (popover) {
                 $(sr).focus();

--- a/www/js/GCT.js
+++ b/www/js/GCT.js
@@ -1780,8 +1780,7 @@ GCTUser = {
             success: function (data) {
                 console.log(data);
                 if (data.result) {
-                    //notificationToastSR(obj, 'friends:add:successful', 'parent');
-                    notificationTempToast(obj, 'friends:add:successful');
+                    notificationToastSR(obj, 'friends:add:successful', 'parent-button');
                 } else if (data.message) {
                     notificationToastSR(obj, 'friends:add:pending', 'parent');
                 }
@@ -3596,6 +3595,14 @@ function notificationToastSR(obj, message, remove) {
     $$('#toast-sr').remove();
     if (remove === 'parent') {
         $$(obj).parent().html('<span id="toast-sr" class="reader-text" tabindex="0">' + GCTLang.Trans(message) + '</span>');
+    } else if (remove === 'button') {
+        $$(obj).addClass('disabled');
+        $$('<span id="toast-sr" class="reader-text" tabindex="0">' + GCTLang.Trans(message) + '</span>').appendTo(obj);
+    } else if (remove === 'parent-button') {
+        //disable object, aria-hide, and append SR text to parent. 
+        $$(obj).addClass('disabled');
+        $$(obj).attr('aria-hidden', 'true');
+        $$('<span id="toast-sr" class="reader-text" tabindex="0">' + GCTLang.Trans(message) + '</span>').appendTo($$(obj).parent());
     }
     $('#toast-sr').focus();
 }

--- a/www/js/GCT.js
+++ b/www/js/GCT.js
@@ -284,17 +284,16 @@
     txtMember: function (object) {
         var content = "<div class='hold-all-card' id='request-" + object.guid + "'>"
             + "<div id='label-" + object.guid + "' class='reader-text' data-guid='" + object.guid + "' data-type='gccollab_user' onclick='ShowProfile(" + object.guid + ");'>" + object.label + "</div>"
-            + "<div class='item-link item-content close-popup close-panel' data-guid='" + object.guid + "' data-type='gccollab_user' onclick='ShowProfile(" + object.guid + ");' aria-hidden='true'>"
+            + "<div class='item-link item-content close-popup close-panel' data-guid='" + object.guid + "' data-type='gccollab_user' onclick='ShowProfile(" + object.guid + ");'>"
             + "<div class='item-inner'>"
             + "<div class='item-title-row no-padding-right'>"
             + "</div>"
-            + "<div class='row ptm'>"
+            + "<div class='row ptm' aria-hidden='true'>"
             + "<div class='col-20 members-icon'><img src='" + object.icon + "' width='50' alt='" + object.name + "'></div>"
             + "<div class='col-80 item-title reg-text'>" + object.name + "<div class='item-text more_text'>" + object.organization + "</div> <div class='item-text more_text'> " + object.job + "</div></div>"
             + "</div>";
         (object.colleaguerequest == true) ? content += object.description : content += '';
-        content += "</div>"
-            + "</div></div>";
+        content +=  "</div></div></div>";
         content = GCT.SetLinks(content);
         return content;
     },
@@ -1031,17 +1030,19 @@ GCTEach = {
         return content;
     },
     Member: function (value) {
-        var label = value.displayName + ': ' + value.job + '. ' + value.organization;
+        var job = value.job || '';
+        var org = value.organization || '';
+        var label = value.displayName + ': ' + job + '. ' + org;
         var description = value.about || GCTLang.Trans('no-profile');
         var content = GCTtxt.txtMember({
             guid: value.user_id,
             icon: value.iconURL,
             name: value.displayName,
-            job: (value.job) ? value.job : '',
+            job: job,
             label: label,
             date: GCTLang.Trans("join-date") + "<em>" + prettyDate(value.dateJoined) + "</em>",
             description: description,
-            organization: (value.organization) ? value.organization : '',
+            organization: org,
         });
         return content;
     },
@@ -1501,15 +1502,18 @@ GCTEach = {
     },
     ColleagueRequest: function (value, obj) {
         var description = '<div class="row" id="request-actions-' + value.user_id+'"><div class="col-50"><span class="button button-fill button-raised" data-guid="' + value.user_id + '" onclick="GCTUser.ApproveColleague(this);">' + GCTLang.Trans("accept") + '</span></div><span class="col-50"><div class="button button-fill button-raised" data-guid="' + value.user_id + '" onclick="GCTUser.DeclineColleague(this);">' + GCTLang.Trans("decline") + '</span></div></div>';
-
+        var job = value.job || '';
+        var org = value.organization || '';
+        var label = value.displayName + ': ' + job + '. ' + org;
         var content = GCTtxt.txtMember({
             guid: value.user_id,
             icon: value.iconURL,
             name: value.displayName,
+            label: label,
             date: GCTLang.Trans("join-date") + "<em>" + prettyDate(value.dateJoined) + "</em>",
             description: description,
-            organization: value.organization,
-            job: (value.job) ? value.job : '',
+            organization: org,
+            job: job,
             colleaguerequest: true
         });
         return content;
@@ -3552,7 +3556,7 @@ function errorConsole(jqXHR, textStatus, errorThrown) {
     app.preloader.hide();
 }
 
-var endOfContent = '<div class="card notification-info item-content"><span class="feedback-text" tabindex="0">' + GCTLang.Trans("end-of-content") + '</span></div>';
+var endOfContent = '<div class="notification-info item-content"><span class="feedback-text" tabindex="0">' + GCTLang.Trans("end-of-content") + '</span></div>';
 // "<span id='focus-" + id + "' class='feedback-text' tabindex='0'>" + message + "</span>";
 
  // returns basic center toast

--- a/www/js/GCT.js
+++ b/www/js/GCT.js
@@ -3466,11 +3466,13 @@ GCT = {
             on: {
                 open: function (popover) {
                     console.log('Popover open');
+                    $$('.page-current').attr('aria-hidden', 'true');
                 },
                 opened: function (popover) {
                     console.log('Popover opened');
                 },
                 closed: function (popover) {
+                    $$('.page-current').attr('aria-hidden', 'false');
                     $(obj).focus();
                 },
             }
@@ -3558,7 +3560,22 @@ function toast(obj, message) {
     var result = app.toast.create({
         text: GCTLang.Trans(message),
         position: 'center',
+        text: 'Toast with additional close button',
+        closeButton: true,
         closeTimeout: 2000,
+        on: {
+                open: function (popover) {
+                    console.log('Popover open');
+                    $$('.page-current').attr('aria-hidden', 'true');
+                },
+                opened: function (popover) {
+                    console.log('Popover opened');
+                },
+                closed: function (popover) {
+                    $$('.page-current').attr('aria-hidden', 'false');
+                    $(obj).focus();
+                },
+            }
     });
     result.open();
     $$(obj).remove();

--- a/www/js/GCT.js
+++ b/www/js/GCT.js
@@ -1780,14 +1780,14 @@ GCTUser = {
             success: function (data) {
                 console.log(data);
                 if (data.result) {
-                    notificationToastSR(obj, 'friends:add:successful', 'parent-button');
+                    notificationToastSR(obj, GCTLang.Trans('friends:add:successful'), 'button');
                 } else if (data.message) {
-                    notificationToastSR(obj, 'friends:add:pending', 'parent');
+                    notificationToastSR(obj, GCTLang.Trans('friends:add:pending'), 'button');
                 }
             },
             error: function (jqXHR, textStatus, errorThrown) {
                 console.log(jqXHR, textStatus, errorThrown);
-                notificationTempToast(obj, 'friends:add:error');
+                notificationTempToastSR(obj, 'friends:add:error');
             }
         });
     },
@@ -1801,7 +1801,7 @@ GCTUser = {
             data: { method: "remove.colleague", user: GCTUser.Email(), profileemail: guid, api_key: api_key_gccollab, lang: GCTLang.Lang() },
             timeout: 12000,
             success: function (data) {
-                notificationToastSR(obj, 'friends:removal:successful', 'parent');
+                notificationToastSR(obj, GCTLang.Trans('friends:removal:successful'), 'button');
             },
             error: function (jqXHR, textStatus, errorThrown) {
                 console.log(jqXHR, textStatus, errorThrown);
@@ -3555,64 +3555,39 @@ function errorConsole(jqXHR, textStatus, errorThrown) {
 
 var endOfContent = '<div class="card"><div class="card-content card-content-padding"><div class="card-content-inner"><div class="item-text">' + GCTLang.Trans("end-of-content") + '</div></div></div></div>';
 
-function toast(obj, message) {
-    var result = app.toast.create({
-        text: GCTLang.Trans(message),
-        position: 'center',
-        closeButton: true,
-        closeTimeout: 2000,
-        on: {
-                open: function (popover) {
-                    console.log('Popover open');
-                    $$('.page-current').attr('aria-hidden', 'true');
-                },
-                opened: function (popover) {
-                    console.log('Popover opened');
-                },
-                closed: function (popover) {
-                    $$('.page-current').attr('aria-hidden', 'false');
-                    $(obj).focus();
-                },
-            }
-    });
-    result.open();
-    $$(obj).remove();
-    return result;
-}
-
+ // returns basic center toast
 function cToast(message) {
     var toast = app.toast.create({
-        text: GCTLang.Trans(message),
+        text: message,
         position: 'center',
         closeTimeout: 3000,
     });
     return toast;
 }
 
-function notificationToastSR(obj, message, remove) {
+ // creates center toast(cToast), extra/sr-text based on input, and focuses toast-sr text.
+function notificationToastSR(obj, message, extra) {
     var result = cToast(message);
     result.open();
-    $$('#toast-sr').remove();
-    if (remove === 'parent') {
-        $$(obj).parent().html('<span id="toast-sr" class="reader-text" tabindex="0">' + GCTLang.Trans(message) + '</span>');
-    } else if (remove === 'button') {
-        $$(obj).addClass('disabled');
-        $$('<span id="toast-sr" class="reader-text" tabindex="0">' + GCTLang.Trans(message) + '</span>').appendTo(obj);
-    } else if (remove === 'parent-button') {
+    $$('#toast-sr').remove(); //remove any old toast message
+    if (extra === 'button') {
         //disable object, aria-hide, and append SR text to parent. 
         $$(obj).addClass('disabled');
         $$(obj).attr('aria-hidden', 'true');
-        $$('<span id="toast-sr" class="reader-text" tabindex="0">' + GCTLang.Trans(message) + '</span>').appendTo($$(obj).parent());
+        $$('<span id="toast-sr" class="reader-text" tabindex="0">' + message + '</span>').appendTo($$(obj).parent());
     }
     $('#toast-sr').focus();
 }
 
-function notificationTempToast(obj, message) {
+ // Append SR to obj. Create srToast, which has lifecycle hooks to set focus to SR object while open, then back to original object.
+function notificationTempToastSR(obj, message) {
+    $$('#toast-sr').remove(); //remove any old toast message
     $$('<span id="toast-sr" class="reader-text" tabindex="0">' + GCTLang.Trans(message) + '</span>').appendTo(obj);
     var toast = srToast(message, '#toast-sr', obj);
     toast.open();
 }
 
+// Toast with lifecycle hooks to set focus to SR object while open, then back to original object.
 function srToast(message, sr, obj) {
     var toast = app.toast.create({
         text: GCTLang.Trans(message),
@@ -3621,9 +3596,6 @@ function srToast(message, sr, obj) {
         on: {
             open: function (popover) {
                 $(sr).focus();
-            },
-            opened: function (popover) {
-                console.log('Popover opened');
             },
             closed: function (popover) {
                 $$(sr).remove();

--- a/www/js/GCT.js
+++ b/www/js/GCT.js
@@ -25,7 +25,7 @@
         return '<span id="focus-' + id + '" class="reader-text" tabindex="0">' + GCTLang.Trans('content-loaded') + '</span>';
     },
     txtResultFeedback: function (id, message) {
-        return "<span id='focus-" + id + "' tabindex='0'>" + message + "</span>";
+        return "<span id='focus-" + id + "' class='feedback-text' tabindex='0'>" + message + "</span>";
     },
     txtAction: function (ref) {
         var action = '';
@@ -1780,9 +1780,9 @@ GCTUser = {
             success: function (data) {
                 console.log(data);
                 if (data.result) {
-                    notificationToastSR(obj, GCTLang.Trans('friends:add:successful'), 'button');
+                    notificationToastSR(obj, GCTLang.Trans('friends:add:successful'), 'disable-parent');
                 } else if (data.message) {
-                    notificationToastSR(obj, GCTLang.Trans('friends:add:pending'), 'button');
+                    notificationToastSR(obj, GCTLang.Trans('friends:add:pending'), 'disable-parent');
                 }
             },
             error: function (jqXHR, textStatus, errorThrown) {
@@ -1801,7 +1801,7 @@ GCTUser = {
             data: { method: "remove.colleague", user: GCTUser.Email(), profileemail: guid, api_key: api_key_gccollab, lang: GCTLang.Lang() },
             timeout: 12000,
             success: function (data) {
-                notificationToastSR(obj, GCTLang.Trans('friends:removal:successful'), 'button');
+                notificationToastSR(obj, GCTLang.Trans('friends:removal:successful'), 'disable-parent');
             },
             error: function (jqXHR, textStatus, errorThrown) {
                 console.log(jqXHR, textStatus, errorThrown);
@@ -1826,8 +1826,7 @@ GCTUser = {
             success: function (data) {
                 console.log(data);
                 if (data.result) {
-                    $$('#request-actions-' + guid).html(GCTtxt.txtResultFeedback(guid, data.result));
-                    $('#focus-' + guid).focus();
+                    notificationCardText(data.result, guid, 'request-actions-' + guid);
                 }
             },
             error: function (jqXHR, textStatus, errorThrown) {
@@ -1852,8 +1851,7 @@ GCTUser = {
             success: function (data) {
                 console.log(data);
                 if (data.result) {
-                    $$('#request-actions-' + guid).html(GCTtxt.txtResultFeedback(guid, data.result));
-                    $('#focus-' + guid).focus();
+                    notificationCardText(data.result, guid, 'request-actions-' + guid);
                 }
             },
             error: function (jqXHR, textStatus, errorThrown) {
@@ -3564,13 +3562,12 @@ function cToast(message) {
     });
     return toast;
 }
-
  // creates center toast(cToast), extra/sr-text based on input, and focuses toast-sr text.
 function notificationToastSR(obj, message, extra) {
     var result = cToast(message);
     result.open();
     $$('#toast-sr').remove(); //remove any old toast message
-    if (extra === 'button') {
+    if (extra === 'disable-parent') {
         //disable object, aria-hide, and append SR text to parent. 
         $$(obj).addClass('disabled');
         $$(obj).attr('aria-hidden', 'true');
@@ -3586,7 +3583,6 @@ function notificationTempToastSR(obj, message) {
     var toast = srToast(message, '#toast-sr', obj);
     toast.open();
 }
-
 // Toast with lifecycle hooks to set focus to SR object while open, then back to original object.
 function srToast(message, sr, obj) {
     var toast = app.toast.create({
@@ -3604,4 +3600,11 @@ function srToast(message, sr, obj) {
         }
     });
     return toast;
+}
+
+// visual text notification
+function notificationCardText(message, guid, container) {
+    $$('#' + container).html(GCTtxt.txtResultFeedback(guid, message));
+    $$('#' + container).addClass('card notification-success item-content');
+    $('#focus-' + guid).focus();
 }

--- a/www/js/GCT.js
+++ b/www/js/GCT.js
@@ -1780,16 +1780,15 @@ GCTUser = {
             success: function (data) {
                 console.log(data);
                 if (data.result) {
-                    var result = toastText(obj, "friends:add:successful");
-                    $('#toast-sr').focus();
+                    //notificationToastSR(obj, 'friends:add:successful', 'parent');
+                    notificationTempToast(obj, 'friends:add:successful');
                 } else if (data.message) {
-                    var result = toastText(obj, "friends:add:pending");
-                    $('#toast-sr').focus();
+                    notificationToastSR(obj, 'friends:add:pending', 'parent');
                 }
             },
             error: function (jqXHR, textStatus, errorThrown) {
                 console.log(jqXHR, textStatus, errorThrown);
-                var result = toast(obj, "friends:add:error");
+                notificationTempToast(obj, 'friends:add:error');
             }
         });
     },
@@ -1803,8 +1802,7 @@ GCTUser = {
             data: { method: "remove.colleague", user: GCTUser.Email(), profileemail: guid, api_key: api_key_gccollab, lang: GCTLang.Lang() },
             timeout: 12000,
             success: function (data) {
-                console.log(data);
-                var result = toast(obj, "friends:removal:successful");
+                notificationToastSR(obj, 'friends:removal:successful', 'parent');
             },
             error: function (jqXHR, textStatus, errorThrown) {
                 console.log(jqXHR, textStatus, errorThrown);
@@ -3583,14 +3581,48 @@ function toast(obj, message) {
     return result;
 }
 
-function toastText(obj, message) {
-    var result = app.toast.create({
+function cToast(message) {
+    var toast = app.toast.create({
         text: GCTLang.Trans(message),
         position: 'center',
         closeTimeout: 3000,
     });
+    return toast;
+}
+
+function notificationToastSR(obj, message, remove) {
+    var result = cToast(message);
     result.open();
-    $$('#toast-sr').remove(); // remove old toast-sr content
-    $$(obj).parent().html('<span id="toast-sr" class="reader-text" tabindex="0">' + GCTLang.Trans(message) + '</span>');
-    return result;
+    $$('#toast-sr').remove();
+    if (remove === 'parent') {
+        $$(obj).parent().html('<span id="toast-sr" class="reader-text" tabindex="0">' + GCTLang.Trans(message) + '</span>');
+    }
+    $('#toast-sr').focus();
+}
+
+function notificationTempToast(obj, message) {
+    $$('<span id="toast-sr" class="reader-text" tabindex="0">' + GCTLang.Trans(message) + '</span>').appendTo(obj);
+    var toast = srToast(message, '#toast-sr', obj);
+    toast.open();
+}
+
+function srToast(message, sr, obj) {
+    var toast = app.toast.create({
+        text: GCTLang.Trans(message),
+        position: 'center',
+        closeTimeout: 3000,
+        on: {
+            open: function (popover) {
+                $(sr).focus();
+            },
+            opened: function (popover) {
+                console.log('Popover opened');
+            },
+            closed: function (popover) {
+                $$(sr).remove();
+                $(obj).focus();
+            },
+        }
+    });
+    return toast;
 }

--- a/www/js/GCT.js
+++ b/www/js/GCT.js
@@ -1780,9 +1780,11 @@ GCTUser = {
             success: function (data) {
                 console.log(data);
                 if (data.result) {
-                    var result = toast(obj, "friends:add:successful");
+                    var result = toastText(obj, "friends:add:successful");
+                    $('#toast-sr').focus();
                 } else if (data.message) {
-                    var result = toast(obj, "friends:add:pending");
+                    var result = toastText(obj, "friends:add:pending");
+                    $('#toast-sr').focus();
                 }
             },
             error: function (jqXHR, textStatus, errorThrown) {
@@ -3560,7 +3562,6 @@ function toast(obj, message) {
     var result = app.toast.create({
         text: GCTLang.Trans(message),
         position: 'center',
-        text: 'Toast with additional close button',
         closeButton: true,
         closeTimeout: 2000,
         on: {
@@ -3579,5 +3580,17 @@ function toast(obj, message) {
     });
     result.open();
     $$(obj).remove();
+    return result;
+}
+
+function toastText(obj, message) {
+    var result = app.toast.create({
+        text: GCTLang.Trans(message),
+        position: 'center',
+        closeTimeout: 3000,
+    });
+    result.open();
+    $$('#toast-sr').remove(); // remove old toast-sr content
+    $$(obj).parent().html('<span id="toast-sr" class="reader-text" tabindex="0">' + GCTLang.Trans(message) + '</span>');
     return result;
 }

--- a/www/js/GCT.js
+++ b/www/js/GCT.js
@@ -1787,7 +1787,7 @@ GCTUser = {
             },
             error: function (jqXHR, textStatus, errorThrown) {
                 console.log(jqXHR, textStatus, errorThrown);
-                notificationTempToastSR(obj, 'friends:add:error');
+                notificationTempToastSR(obj, GCTLang.Trans('friends:add:error'));
             }
         });
     },
@@ -1831,6 +1831,7 @@ GCTUser = {
             },
             error: function (jqXHR, textStatus, errorThrown) {
                 console.log(jqXHR, textStatus, errorThrown);
+                notificationTempToastSR(obj, errorThrown);
             }
         });
     },
@@ -3579,14 +3580,14 @@ function notificationToastSR(obj, message, extra) {
  // Append SR to obj. Create srToast, which has lifecycle hooks to set focus to SR object while open, then back to original object.
 function notificationTempToastSR(obj, message) {
     $$('#toast-sr').remove(); //remove any old toast message
-    $$('<span id="toast-sr" class="reader-text" tabindex="0">' + GCTLang.Trans(message) + '</span>').appendTo(obj);
+    $$('<span id="toast-sr" class="reader-text" tabindex="0">' + message + '</span>').appendTo(obj);
     var toast = srToast(message, '#toast-sr', obj);
     toast.open();
 }
 // Toast with lifecycle hooks to set focus to SR object while open, then back to original object.
 function srToast(message, sr, obj) {
     var toast = app.toast.create({
-        text: GCTLang.Trans(message),
+        text: message,
         position: 'center',
         closeTimeout: 3000,
         on: {

--- a/www/js/Lang.js
+++ b/www/js/Lang.js
@@ -432,7 +432,7 @@
 
     "friends:add:successful": "Successfully added as a colleague.",
     "friends:add:pending": "Requested to be colleagues.",
-    "friends:add:error": "We couldn't add as a colleague.",
+    "friends:add:error": "Could not add as a colleague.",
     "friends:removal:successful": "Successfully removed from your colleagues.",
 }
 

--- a/www/js/gccollab.js
+++ b/www/js/gccollab.js
@@ -202,9 +202,11 @@ function ShowProfileSheet(obj) {
         on: {
             opened: function (sheet) {
                 $('#sheet-focus-' + guid).focus();
+                $$('.page-current').attr('aria-hidden', 'true');
             },
             closed: function (sheet) {
                 $(obj).focus();
+                $$('.page-current').attr('aria-hidden', 'false');
             },
         }
     });
@@ -393,6 +395,10 @@ $$(document).on('page:init', '.page[data-name="post-opp"]', function (e) {
 })
 
 $$('.panel-left').on('panel:open', function () {
+    $$('.page-current').attr('aria-hidden', 'true');
     var focusTitle = document.getElementById('menu-panel');
     if (focusTitle) { focusTitle.focus(); }
+});
+$$('.panel-left').on('panel:close', function () {
+    $$('.page-current').attr('aria-hidden', 'false');
 });

--- a/www/pages/list-template.html
+++ b/www/pages/list-template.html
@@ -248,10 +248,12 @@
                 }
                 if (page === 'home') {
                     $$('.popover-actions-home').on('popover:opened', function (e, popover) {
+                        $$('.page-current').attr('aria-hidden', 'true');
                         var focusTitle = document.getElementById('home-actions-title');
                         if (focusTitle) { focusTitle.focus(); }
                     });
                     $$('.popover-actions-home').on('popover:close', function () {
+                        $$('.page-current').attr('aria-hidden', 'false');
                         var focusNow = document.getElementById(page + '-actions');
                         if (focusNow) { focusNow.focus(); }
                     });

--- a/www/pages/profile-template.html
+++ b/www/pages/profile-template.html
@@ -192,10 +192,12 @@
                     if (focusNow) { focusNow.focus(); }
                 });
                 $$('.popover-actions-' + guid).on('popover:open', function () {
+                    $$('.page-current').attr('aria-hidden', 'true');
                     var focusNow = document.getElementById(guid + '-actions-title');
                     if (focusNow) { focusNow.focus(); }
                 });
                 $$('.popover-actions-' + guid).on('popover:close', function () {
+                    $$('.page-current').attr('aria-hidden', 'false');
                     var focusNow = document.getElementById('actions-' + guid);
                     if (focusNow) { focusNow.focus(); }
                 });

--- a/www/pages/profile-template.html
+++ b/www/pages/profile-template.html
@@ -182,10 +182,12 @@
                     });
                 });
                 $$('.popover-links-' + guid).on('popover:close', function () {
+                    $$('.page-current').attr('aria-hidden', 'false');
                     var focusNow = document.getElementById('profile-menu-' + guid);
                     if (focusNow) { focusNow.focus(); }
                 });
                 $$('.popover-links-' + guid).on('popover:open', function () {
+                    $$('.page-current').attr('aria-hidden', 'true');
                     var focusNow = document.getElementById('focus-links-popover-' + guid);
                     if (focusNow) { focusNow.focus(); }
                 });


### PR DESCRIPTION
Tested and implemented focus traps for SidePanel, Sheet Modal, Popovers. 
Ended up with deciding on aria-hidden on anything outside of the component (so just on class current-page) was the best option with screen-readers. F7 lifecycle hooks made them easy to setup.
closes #346 

Worked through how to give feedback/notifications without alerts, due to them not working well with lifecycle hooks used for other component focus traps. 

`notificationToastSR(obj, mesage, extra, type)` Toast + SR text + extra used for specifics (ie disable buttons) Focus set to SR text. Used with on page actions like Join Group button or Add Colleague button.

`notificationTempToastSR(obj, message, type)`  Toast + SR text: SR text removed on toast close. Focus set to SR text, and back to original obj on toast close. Used for page actions that error, with ability to try again, such as error on Approve Colleague. 

`notificationCardText(message, guid, container)` Text formated and replaces container. Focus set to text. Used for in-list feedback, such as Colleague Requests page. 

Notifications setup on AddColleague, RemoveColleague, ApproveColleague, DeclineColleague, JoinGroup, LeaveGroup. More can be done, but waiting to figure out #344 to reduce number of things to change multiple times. 

Part of #343 

notification css classes based on design-system colors
EndOfContent card changed color/shape